### PR TITLE
add raylib target for macos-aarch64

### DIFF
--- a/libraries/raylib.c3l/manifest.json
+++ b/libraries/raylib.c3l/manifest.json
@@ -1,18 +1,17 @@
 { 
   "provides" : "raylib",
   "targets" : {
+    "macos-aarch64" : {
+     "linked-libraries" : ["raylib", "Cocoa.framework", "OpenGL.framework", "CoreVideo.framework", "GLUT.framework", "IOKit.framework", "c"]
+    },
     "macos-x64" : {
-      "linkflags" : [],
-      "dependencies" : [],
-      "linked-libs" : ["raylib", "Cocoa.framework", "OpenGL.framework", "CoreVideo.framework", "GLUT.framework", "IOKit.framework", "c"]
+      "linked-libraries" : ["raylib", "Cocoa.framework", "OpenGL.framework", "CoreVideo.framework", "GLUT.framework", "IOKit.framework", "c"]
     },
     "linux-x64" : {
-      "linkflags" : [],
-      "dependencies" : [],
-      "linked-libs" : ["raylib", "GLESv2", "glfw3", "c"]
+     "linked-libraries" : ["raylib", "GLESv2", "glfw3", "c"]
     },
-	"windows-x64" : {
-		"linked-libs" : ["raylib", "opengl32", "kernel32", "user32", "gdi32", "winmm", "winspool", "comdlg32", "advapi32", "shell32", "ole32", "oleaut32", "uuid", "odbc32", "odbccp32"]
-	}
+    "windows-x64" : {
+      "linked-libraries" : ["raylib", "opengl32", "kernel32", "user32", "gdi32", "winmm", "winspool", "comdlg32", "advapi32", "shell32", "ole32", "oleaut32", "uuid", "odbc32", "odbccp32"]
+    }
   }
 }


### PR DESCRIPTION
Just adding an extra target to Raylib so it'll work on macos-aarch64. Also changed a couple of deprecated property names for their new versions.