### PR TITLE
Fix compile error for GL_VERSION 43+ caused by shadowing of debugMessageCallback

### DIFF
--- a/libraries/opengl.c3l/opengl.c3i
+++ b/libraries/opengl.c3l/opengl.c3i
@@ -22,4 +22,3 @@ distinct GLclampd = double;
 distinct GLhalf = ushort;
 distinct GLsync = uptr;
 def GLDebugProc = fn void(GLenum source,GLenum type,CUInt id,GLenum severity,usz length,ZString message, void *userParam);
-fn void debugMessageCallback(GLDebugProc callback, void* userParam) @extern("glDebugMessageCallback");


### PR DESCRIPTION
Fixed a compile error that occurred when using "GL_VERSION = 43" and higher due to the shadowing of the "debugMessageCallback" function. The function was declared both in the general OpenGL module and in the OpenGL 4.3+ version-specific modules, causing a conflict. Removed the redundant declaration from the general module, as this callback is only relevant for OpenGL 4.3 and above.

Compiling versions lower than 4.3 works without this fix.

Tested the solution with GL_VERSION = [31, 32, 33, 40, 41, 42, 43, 44, 45, 46]. No issues detected.