### PR TITLE
`raylib.c3l` & `raylib5.c3l`: fix `cannot find -lglfw3: No such file or directory`

### DIFF
--- a/libraries/raylib.c3l/manifest.json
+++ b/libraries/raylib.c3l/manifest.json
@@ -14,7 +14,7 @@
     "linux-x64" : {
       "link-args" : [],
       "dependencies" : [],
-      "linked-libraries" : ["raylib", "GLESv2", "glfw3", "c"]
+      "linked-libraries" : ["raylib", "GLESv2", "glfw", "c"]
     },
 	"windows-x64" : {
 		"linked-libraries" : ["raylib", "opengl32", "kernel32", "user32", "gdi32", "winmm", "winspool", "comdlg32", "advapi32", "shell32", "ole32", "oleaut32", "uuid", "odbc32", "odbccp32"],

--- a/libraries/raylib5.c3l/manifest.json
+++ b/libraries/raylib5.c3l/manifest.json
@@ -14,7 +14,7 @@
     "linux-x64" : {
       "link-args" : [],
       "dependencies" : [],
-      "linked-libraries" : ["raylib", "GLESv2", "glfw3", "c"]
+      "linked-libraries" : ["raylib", "GLESv2", "glfw", "c"]
     },
 	"windows-x64" : {
 		"linked-libraries" : ["raylib", "opengl32", "kernel32", "user32", "gdi32", "winmm", "winspool", "comdlg32", "advapi32", "shell32", "ole32", "oleaut32", "uuid", "odbc32", "odbccp32"],


### PR DESCRIPTION
fixes #29 

I have tested on Arch, Fedora 40, Debian 12, Ubuntu 22.04, and OpenSUSE tumbleweed.

it correctly links with glfw3:
```sh
$ pkg-config --libs glfw3
-lglfw
```