### PR TITLE
Fix `curl_slist_append` extern name

### DIFF
--- a/libraries/curl.c3l/curl.c3i
+++ b/libraries/curl.c3l/curl.c3i
@@ -1361,7 +1361,7 @@ fn CURLcode global_init(long flags) @extern("curl_global_init");
 fn CURLcode global_init_mem(long flags, Curl_malloc_callback m, Curl_free_callback f, Curl_realloc_callback r, Curl_strdup_callback s, Curl_calloc_callback c) @extern("curl_global_init_mem");
 fn void global_cleanup() @extern("curl_global_cleanup");
 fn CurlSslset global_sslset(Sslbackend id, char* name, Ssl_backend ***avail) @extern("curl_global_sslset");
-fn Slist *slist_append(Slist *list, char* data) @extern("curl_slist");
+fn Slist *slist_append(Slist *list, char* data) @extern("curl_slist_append");
 fn void slist_free_all(Slist *list) @extern("curl_slist_free_all");
 fn libc::Time_t getdate(char* p, libc::Time_t *unused) @extern("curl_getdate");
 fn void* share_init() @extern("curl_share_init");


### PR DESCRIPTION
Fix typo in `@extern` attribute of `slist_append` function