### PR TITLE
Fix blendMode macro in raylib5.c3l/raylib.c3i.

### DIFF
--- a/libraries/raylib5.c3l/raylib.c3i
+++ b/libraries/raylib5.c3l/raylib.c3i
@@ -1889,8 +1889,8 @@ macro void @shaderMode(Shader shader ;@body)
 *>
 macro void @blendMode(BlendMode mode ;@body)
 {
-  beginShaderMode(mode);
-  defer endShaderMode();
+  beginBlendMode((int)mode);
+  defer endBlendMode();
   @body();
 }
 


### PR DESCRIPTION
Ran into this while working with the bindings. The current `@blendMode` macro is actually calling `beginShaderMode` and `endShaderMode`. Just a quick patch to correct it to `beginBlendMode` and `endBlendMode`.