### PR TITLE
Fix sizes of audio-related structs in sdl2.c3l

### DIFF
--- a/libraries/sdl2.c3l/sdl2.c3i
+++ b/libraries/sdl2.c3l/sdl2.c3i
@@ -134,7 +134,7 @@ struct RWops
 	}
 }
 
-alias AudioFormat = int;
+alias AudioFormat = ushort;
 
 alias AudioCallback = fn void(void *userdata, char* stream, int len);
 
@@ -144,8 +144,8 @@ struct AudioSpec
 	AudioFormat format;
 	char channels;
 	char silence;
-	uint samples;
-	uint padding;
+	ushort samples;
+	ushort padding;
 	uint size;
 	AudioCallback callback;
 	void *userdata;


### PR DESCRIPTION
Audio callbacks wouldn't work, so I made this quick PR to fix it