### PR TITLE
make vulkan enums `const` instead of using `: int (int value)`

### DIFF
--- a/libraries/vulkan.c3l/vk10.c3i
+++ b/libraries/vulkan.c3l/vk10.c3i
@@ -72,20 +72,20 @@ typedef VkQueryPool = uptr;
 typedef VkFramebuffer = uptr;
 typedef VkRenderPass = uptr;
 typedef VkPipelineCache = uptr;
-enum VkAttachmentLoadOp  : int (int value)
+enum VkAttachmentLoadOp  : const int
 {
     VK_ATTACHMENT_LOAD_OP_LOAD = 0,
     VK_ATTACHMENT_LOAD_OP_CLEAR = 1,
     VK_ATTACHMENT_LOAD_OP_DONT_CARE = 2,
     VK_ATTACHMENT_LOAD_OP_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkAttachmentStoreOp  : int (int value)
+enum VkAttachmentStoreOp  : const int
 {
     VK_ATTACHMENT_STORE_OP_STORE = 0,
     VK_ATTACHMENT_STORE_OP_DONT_CARE = 1,
     VK_ATTACHMENT_STORE_OP_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkBlendFactor  : int (int value)
+enum VkBlendFactor  : const int
 {
     VK_BLEND_FACTOR_ZERO = 0,
     VK_BLEND_FACTOR_ONE = 1,
@@ -108,7 +108,7 @@ enum VkBlendFactor  : int (int value)
     VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA = 18,
     VK_BLEND_FACTOR_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkBlendOp  : int (int value)
+enum VkBlendOp  : const int
 {
     VK_BLEND_OP_ADD = 0,
     VK_BLEND_OP_SUBTRACT = 1,
@@ -117,7 +117,7 @@ enum VkBlendOp  : int (int value)
     VK_BLEND_OP_MAX = 4,
     VK_BLEND_OP_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkBorderColor  : int (int value)
+enum VkBorderColor  : const int
 {
     VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK = 0,
     VK_BORDER_COLOR_INT_TRANSPARENT_BLACK = 1,
@@ -127,19 +127,19 @@ enum VkBorderColor  : int (int value)
     VK_BORDER_COLOR_INT_OPAQUE_WHITE = 5,
     VK_BORDER_COLOR_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPipelineCacheHeaderVersion  : int (int value)
+enum VkPipelineCacheHeaderVersion  : const int
 {
     VK_PIPELINE_CACHE_HEADER_VERSION_ONE = 1,
     VK_PIPELINE_CACHE_HEADER_VERSION_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkBufferCreateFlagBits  : int (int value)
+enum VkBufferCreateFlagBits  : const int
 {
     VK_BUFFER_CREATE_SPARSE_BINDING_BIT = 1,
     VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT = 2,
     VK_BUFFER_CREATE_SPARSE_ALIASED_BIT = 4,
     VK_BUFFER_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkBufferUsageFlagBits  : int (int value)
+enum VkBufferUsageFlagBits  : const int
 {
     VK_BUFFER_USAGE_TRANSFER_SRC_BIT = 1,
     VK_BUFFER_USAGE_TRANSFER_DST_BIT = 2,
@@ -152,7 +152,7 @@ enum VkBufferUsageFlagBits  : int (int value)
     VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT = 256,
     VK_BUFFER_USAGE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkColorComponentFlagBits  : int (int value)
+enum VkColorComponentFlagBits  : const int
 {
     VK_COLOR_COMPONENT_R_BIT = 1,
     VK_COLOR_COMPONENT_G_BIT = 2,
@@ -160,7 +160,7 @@ enum VkColorComponentFlagBits  : int (int value)
     VK_COLOR_COMPONENT_A_BIT = 8,
     VK_COLOR_COMPONENT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkComponentSwizzle  : int (int value)
+enum VkComponentSwizzle  : const int
 {
     VK_COMPONENT_SWIZZLE_IDENTITY = 0,
     VK_COMPONENT_SWIZZLE_ZERO = 1,
@@ -171,36 +171,36 @@ enum VkComponentSwizzle  : int (int value)
     VK_COMPONENT_SWIZZLE_A = 6,
     VK_COMPONENT_SWIZZLE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCommandPoolCreateFlagBits  : int (int value)
+enum VkCommandPoolCreateFlagBits  : const int
 {
     VK_COMMAND_POOL_CREATE_TRANSIENT_BIT = 1,
     VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT = 2,
     VK_COMMAND_POOL_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCommandPoolResetFlagBits  : int (int value)
+enum VkCommandPoolResetFlagBits  : const int
 {
     VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT = 1,
     VK_COMMAND_POOL_RESET_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCommandBufferResetFlagBits  : int (int value)
+enum VkCommandBufferResetFlagBits  : const int
 {
     VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT = 1,
     VK_COMMAND_BUFFER_RESET_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCommandBufferLevel  : int (int value)
+enum VkCommandBufferLevel  : const int
 {
     VK_COMMAND_BUFFER_LEVEL_PRIMARY = 0,
     VK_COMMAND_BUFFER_LEVEL_SECONDARY = 1,
     VK_COMMAND_BUFFER_LEVEL_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCommandBufferUsageFlagBits  : int (int value)
+enum VkCommandBufferUsageFlagBits  : const int
 {
     VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT = 1,
     VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT = 2,
     VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT = 4,
     VK_COMMAND_BUFFER_USAGE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCompareOp  : int (int value)
+enum VkCompareOp  : const int
 {
     VK_COMPARE_OP_NEVER = 0,
     VK_COMPARE_OP_LESS = 1,
@@ -212,7 +212,7 @@ enum VkCompareOp  : int (int value)
     VK_COMPARE_OP_ALWAYS = 7,
     VK_COMPARE_OP_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCullModeFlagBits  : int (int value)
+enum VkCullModeFlagBits  : const int
 {
     VK_CULL_MODE_NONE = 0,
     VK_CULL_MODE_FRONT_BIT = 1,
@@ -220,7 +220,7 @@ enum VkCullModeFlagBits  : int (int value)
     VK_CULL_MODE_FRONT_AND_BACK = 0x00000003,
     VK_CULL_MODE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDescriptorType  : int (int value)
+enum VkDescriptorType  : const int
 {
     VK_DESCRIPTOR_TYPE_SAMPLER = 0,
     VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER = 1,
@@ -235,7 +235,7 @@ enum VkDescriptorType  : int (int value)
     VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT = 10,
     VK_DESCRIPTOR_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDynamicState  : int (int value)
+enum VkDynamicState  : const int
 {
     VK_DYNAMIC_STATE_VIEWPORT = 0,
     VK_DYNAMIC_STATE_SCISSOR = 1,
@@ -248,19 +248,19 @@ enum VkDynamicState  : int (int value)
     VK_DYNAMIC_STATE_STENCIL_REFERENCE = 8,
     VK_DYNAMIC_STATE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkFenceCreateFlagBits  : int (int value)
+enum VkFenceCreateFlagBits  : const int
 {
     VK_FENCE_CREATE_SIGNALED_BIT = 1,
     VK_FENCE_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPolygonMode  : int (int value)
+enum VkPolygonMode  : const int
 {
     VK_POLYGON_MODE_FILL = 0,
     VK_POLYGON_MODE_LINE = 1,
     VK_POLYGON_MODE_POINT = 2,
     VK_POLYGON_MODE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkFormat  : int (int value)
+enum VkFormat  : const int
 {
     VK_FORMAT_UNDEFINED = 0,
     VK_FORMAT_R4G4_UNORM_PACK8 = 1,
@@ -449,7 +449,7 @@ enum VkFormat  : int (int value)
     VK_FORMAT_ASTC_12X12_SRGB_BLOCK = 184,
     VK_FORMAT_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkFormatFeatureFlagBits  : int (int value)
+enum VkFormatFeatureFlagBits  : const int
 {
     VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT = 1,
     VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT = 2,
@@ -466,13 +466,13 @@ enum VkFormatFeatureFlagBits  : int (int value)
     VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT = 4096,
     VK_FORMAT_FEATURE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkFrontFace  : int (int value)
+enum VkFrontFace  : const int
 {
     VK_FRONT_FACE_COUNTER_CLOCKWISE = 0,
     VK_FRONT_FACE_CLOCKWISE = 1,
     VK_FRONT_FACE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageAspectFlagBits  : int (int value)
+enum VkImageAspectFlagBits  : const int
 {
     VK_IMAGE_ASPECT_COLOR_BIT = 1,
     VK_IMAGE_ASPECT_DEPTH_BIT = 2,
@@ -480,7 +480,7 @@ enum VkImageAspectFlagBits  : int (int value)
     VK_IMAGE_ASPECT_METADATA_BIT = 8,
     VK_IMAGE_ASPECT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageCreateFlagBits  : int (int value)
+enum VkImageCreateFlagBits  : const int
 {
     VK_IMAGE_CREATE_SPARSE_BINDING_BIT = 1,
     VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT = 2,
@@ -489,7 +489,7 @@ enum VkImageCreateFlagBits  : int (int value)
     VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT = 16,
     VK_IMAGE_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageLayout  : int (int value)
+enum VkImageLayout  : const int
 {
     VK_IMAGE_LAYOUT_UNDEFINED = 0,
     VK_IMAGE_LAYOUT_GENERAL = 1,
@@ -502,20 +502,20 @@ enum VkImageLayout  : int (int value)
     VK_IMAGE_LAYOUT_PREINITIALIZED = 8,
     VK_IMAGE_LAYOUT_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageTiling  : int (int value)
+enum VkImageTiling  : const int
 {
     VK_IMAGE_TILING_OPTIMAL = 0,
     VK_IMAGE_TILING_LINEAR = 1,
     VK_IMAGE_TILING_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageType  : int (int value)
+enum VkImageType  : const int
 {
     VK_IMAGE_TYPE_1D = 0,
     VK_IMAGE_TYPE_2D = 1,
     VK_IMAGE_TYPE_3D = 2,
     VK_IMAGE_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageUsageFlagBits  : int (int value)
+enum VkImageUsageFlagBits  : const int
 {
     VK_IMAGE_USAGE_TRANSFER_SRC_BIT = 1,
     VK_IMAGE_USAGE_TRANSFER_DST_BIT = 2,
@@ -527,7 +527,7 @@ enum VkImageUsageFlagBits  : int (int value)
     VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT = 128,
     VK_IMAGE_USAGE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageViewType  : int (int value)
+enum VkImageViewType  : const int
 {
     VK_IMAGE_VIEW_TYPE_1D = 0,
     VK_IMAGE_VIEW_TYPE_2D = 1,
@@ -538,19 +538,19 @@ enum VkImageViewType  : int (int value)
     VK_IMAGE_VIEW_TYPE_CUBE_ARRAY = 6,
     VK_IMAGE_VIEW_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSharingMode  : int (int value)
+enum VkSharingMode  : const int
 {
     VK_SHARING_MODE_EXCLUSIVE = 0,
     VK_SHARING_MODE_CONCURRENT = 1,
     VK_SHARING_MODE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkIndexType  : int (int value)
+enum VkIndexType  : const int
 {
     VK_INDEX_TYPE_UINT16 = 0,
     VK_INDEX_TYPE_UINT32 = 1,
     VK_INDEX_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkLogicOp  : int (int value)
+enum VkLogicOp  : const int
 {
     VK_LOGIC_OP_CLEAR = 0,
     VK_LOGIC_OP_AND = 1,
@@ -570,12 +570,12 @@ enum VkLogicOp  : int (int value)
     VK_LOGIC_OP_SET = 15,
     VK_LOGIC_OP_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkMemoryHeapFlagBits  : int (int value)
+enum VkMemoryHeapFlagBits  : const int
 {
     VK_MEMORY_HEAP_DEVICE_LOCAL_BIT = 1,
     VK_MEMORY_HEAP_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkAccessFlagBits  : int (int value)
+enum VkAccessFlagBits  : const int
 {
     VK_ACCESS_INDIRECT_COMMAND_READ_BIT = 1,
     VK_ACCESS_INDEX_READ_BIT = 2,
@@ -596,7 +596,7 @@ enum VkAccessFlagBits  : int (int value)
     VK_ACCESS_MEMORY_WRITE_BIT = 65536,
     VK_ACCESS_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkMemoryPropertyFlagBits  : int (int value)
+enum VkMemoryPropertyFlagBits  : const int
 {
     VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT = 1,
     VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT = 2,
@@ -605,7 +605,7 @@ enum VkMemoryPropertyFlagBits  : int (int value)
     VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT = 16,
     VK_MEMORY_PROPERTY_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPhysicalDeviceType  : int (int value)
+enum VkPhysicalDeviceType  : const int
 {
     VK_PHYSICAL_DEVICE_TYPE_OTHER = 0,
     VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU = 1,
@@ -614,20 +614,20 @@ enum VkPhysicalDeviceType  : int (int value)
     VK_PHYSICAL_DEVICE_TYPE_CPU = 4,
     VK_PHYSICAL_DEVICE_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPipelineBindPoint  : int (int value)
+enum VkPipelineBindPoint  : const int
 {
     VK_PIPELINE_BIND_POINT_GRAPHICS = 0,
     VK_PIPELINE_BIND_POINT_COMPUTE = 1,
     VK_PIPELINE_BIND_POINT_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPipelineCreateFlagBits  : int (int value)
+enum VkPipelineCreateFlagBits  : const int
 {
     VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT = 1,
     VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT = 2,
     VK_PIPELINE_CREATE_DERIVATIVE_BIT = 4,
     VK_PIPELINE_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPrimitiveTopology  : int (int value)
+enum VkPrimitiveTopology  : const int
 {
     VK_PRIMITIVE_TOPOLOGY_POINT_LIST = 0,
     VK_PRIMITIVE_TOPOLOGY_LINE_LIST = 1,
@@ -642,12 +642,12 @@ enum VkPrimitiveTopology  : int (int value)
     VK_PRIMITIVE_TOPOLOGY_PATCH_LIST = 10,
     VK_PRIMITIVE_TOPOLOGY_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkQueryControlFlagBits  : int (int value)
+enum VkQueryControlFlagBits  : const int
 {
     VK_QUERY_CONTROL_PRECISE_BIT = 1,
     VK_QUERY_CONTROL_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkQueryPipelineStatisticFlagBits  : int (int value)
+enum VkQueryPipelineStatisticFlagBits  : const int
 {
     VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT = 1,
     VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_PRIMITIVES_BIT = 2,
@@ -662,7 +662,7 @@ enum VkQueryPipelineStatisticFlagBits  : int (int value)
     VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT = 1024,
     VK_QUERY_PIPELINE_STATISTIC_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkQueryResultFlagBits  : int (int value)
+enum VkQueryResultFlagBits  : const int
 {
     VK_QUERY_RESULT_64_BIT = 1,
     VK_QUERY_RESULT_WAIT_BIT = 2,
@@ -670,14 +670,14 @@ enum VkQueryResultFlagBits  : int (int value)
     VK_QUERY_RESULT_PARTIAL_BIT = 8,
     VK_QUERY_RESULT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkQueryType  : int (int value)
+enum VkQueryType  : const int
 {
     VK_QUERY_TYPE_OCCLUSION = 0,
     VK_QUERY_TYPE_PIPELINE_STATISTICS = 1,
     VK_QUERY_TYPE_TIMESTAMP = 2,
     VK_QUERY_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkQueueFlagBits  : int (int value)
+enum VkQueueFlagBits  : const int
 {
     VK_QUEUE_GRAPHICS_BIT = 1,
     VK_QUEUE_COMPUTE_BIT = 2,
@@ -685,13 +685,13 @@ enum VkQueueFlagBits  : int (int value)
     VK_QUEUE_SPARSE_BINDING_BIT = 8,
     VK_QUEUE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSubpassContents  : int (int value)
+enum VkSubpassContents  : const int
 {
     VK_SUBPASS_CONTENTS_INLINE = 0,
     VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS = 1,
     VK_SUBPASS_CONTENTS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkResult  : int (int value)
+enum VkResult  : const int
 {
     VK_SUCCESS = 0,
     VK_NOT_READY = 1,
@@ -714,7 +714,7 @@ enum VkResult  : int (int value)
     VK_ERROR_UNKNOWN = -13,
     VK_RESULT_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkShaderStageFlagBits  : int (int value)
+enum VkShaderStageFlagBits  : const int
 {
     VK_SHADER_STAGE_VERTEX_BIT = 1,
     VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT = 2,
@@ -726,12 +726,12 @@ enum VkShaderStageFlagBits  : int (int value)
     VK_SHADER_STAGE_ALL = 0x7FFFFFFF,
     VK_SHADER_STAGE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSparseMemoryBindFlagBits  : int (int value)
+enum VkSparseMemoryBindFlagBits  : const int
 {
     VK_SPARSE_MEMORY_BIND_METADATA_BIT = 1,
     VK_SPARSE_MEMORY_BIND_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkStencilFaceFlagBits  : int (int value)
+enum VkStencilFaceFlagBits  : const int
 {
     VK_STENCIL_FACE_FRONT_BIT = 1,
     VK_STENCIL_FACE_BACK_BIT = 2,
@@ -739,7 +739,7 @@ enum VkStencilFaceFlagBits  : int (int value)
     VK_STENCIL_FRONT_AND_BACK = 0x00000003,
     VK_STENCIL_FACE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkStencilOp  : int (int value)
+enum VkStencilOp  : const int
 {
     VK_STENCIL_OP_KEEP = 0,
     VK_STENCIL_OP_ZERO = 1,
@@ -751,7 +751,7 @@ enum VkStencilOp  : int (int value)
     VK_STENCIL_OP_DECREMENT_AND_WRAP = 7,
     VK_STENCIL_OP_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkStructureType  : int (int value)
+enum VkStructureType  : const int
 {
     VK_STRUCTURE_TYPE_APPLICATION_INFO = 0,
     VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO = 1,
@@ -804,7 +804,7 @@ enum VkStructureType  : int (int value)
     VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO = 48,
     VK_STRUCTURE_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSystemAllocationScope  : int (int value)
+enum VkSystemAllocationScope  : const int
 {
     VK_SYSTEM_ALLOCATION_SCOPE_COMMAND = 0,
     VK_SYSTEM_ALLOCATION_SCOPE_OBJECT = 1,
@@ -813,12 +813,12 @@ enum VkSystemAllocationScope  : int (int value)
     VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE = 4,
     VK_SYSTEM_ALLOCATION_SCOPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkInternalAllocationType  : int (int value)
+enum VkInternalAllocationType  : const int
 {
     VK_INTERNAL_ALLOCATION_TYPE_EXECUTABLE = 0,
     VK_INTERNAL_ALLOCATION_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSamplerAddressMode  : int (int value)
+enum VkSamplerAddressMode  : const int
 {
     VK_SAMPLER_ADDRESS_MODE_REPEAT = 0,
     VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT = 1,
@@ -826,25 +826,25 @@ enum VkSamplerAddressMode  : int (int value)
     VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER = 3,
     VK_SAMPLER_ADDRESS_MODE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkFilter  : int (int value)
+enum VkFilter  : const int
 {
     VK_FILTER_NEAREST = 0,
     VK_FILTER_LINEAR = 1,
     VK_FILTER_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSamplerMipmapMode  : int (int value)
+enum VkSamplerMipmapMode  : const int
 {
     VK_SAMPLER_MIPMAP_MODE_NEAREST = 0,
     VK_SAMPLER_MIPMAP_MODE_LINEAR = 1,
     VK_SAMPLER_MIPMAP_MODE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkVertexInputRate  : int (int value)
+enum VkVertexInputRate  : const int
 {
     VK_VERTEX_INPUT_RATE_VERTEX = 0,
     VK_VERTEX_INPUT_RATE_INSTANCE = 1,
     VK_VERTEX_INPUT_RATE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPipelineStageFlagBits  : int (int value)
+enum VkPipelineStageFlagBits  : const int
 {
     VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT = 1,
     VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT = 2,
@@ -865,14 +865,14 @@ enum VkPipelineStageFlagBits  : int (int value)
     VK_PIPELINE_STAGE_ALL_COMMANDS_BIT = 65536,
     VK_PIPELINE_STAGE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSparseImageFormatFlagBits  : int (int value)
+enum VkSparseImageFormatFlagBits  : const int
 {
     VK_SPARSE_IMAGE_FORMAT_SINGLE_MIPTAIL_BIT = 1,
     VK_SPARSE_IMAGE_FORMAT_ALIGNED_MIP_SIZE_BIT = 2,
     VK_SPARSE_IMAGE_FORMAT_NONSTANDARD_BLOCK_SIZE_BIT = 4,
     VK_SPARSE_IMAGE_FORMAT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSampleCountFlagBits  : int (int value)
+enum VkSampleCountFlagBits  : const int
 {
     VK_SAMPLE_COUNT_1_BIT = 1,
     VK_SAMPLE_COUNT_2_BIT = 2,
@@ -883,22 +883,22 @@ enum VkSampleCountFlagBits  : int (int value)
     VK_SAMPLE_COUNT_64_BIT = 64,
     VK_SAMPLE_COUNT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkAttachmentDescriptionFlagBits  : int (int value)
+enum VkAttachmentDescriptionFlagBits  : const int
 {
     VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT = 1,
     VK_ATTACHMENT_DESCRIPTION_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDescriptorPoolCreateFlagBits  : int (int value)
+enum VkDescriptorPoolCreateFlagBits  : const int
 {
     VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT = 1,
     VK_DESCRIPTOR_POOL_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDependencyFlagBits  : int (int value)
+enum VkDependencyFlagBits  : const int
 {
     VK_DEPENDENCY_BY_REGION_BIT = 1,
     VK_DEPENDENCY_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkObjectType  : int (int value)
+enum VkObjectType  : const int
 {
     VK_OBJECT_TYPE_UNKNOWN = 0,
     VK_OBJECT_TYPE_INSTANCE = 1,
@@ -928,7 +928,7 @@ enum VkObjectType  : int (int value)
     VK_OBJECT_TYPE_COMMAND_POOL = 25,
     VK_OBJECT_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkVendorId  : int (int value)
+enum VkVendorId  : const int
 {
     VK_VENDOR_ID_KHRONOS = 0x10000,
     VK_VENDOR_ID_VIV = 0x10001,

--- a/libraries/vulkan.c3l/vk11.c3i
+++ b/libraries/vulkan.c3l/vk11.c3i
@@ -79,20 +79,20 @@ typedef VkRenderPass = uptr;
 typedef VkPipelineCache = uptr;
 typedef VkDescriptorUpdateTemplate = uptr;
 typedef VkSamplerYcbcrConversion = uptr;
-enum VkAttachmentLoadOp  : int (int value)
+enum VkAttachmentLoadOp  : const int
 {
     VK_ATTACHMENT_LOAD_OP_LOAD = 0,
     VK_ATTACHMENT_LOAD_OP_CLEAR = 1,
     VK_ATTACHMENT_LOAD_OP_DONT_CARE = 2,
     VK_ATTACHMENT_LOAD_OP_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkAttachmentStoreOp  : int (int value)
+enum VkAttachmentStoreOp  : const int
 {
     VK_ATTACHMENT_STORE_OP_STORE = 0,
     VK_ATTACHMENT_STORE_OP_DONT_CARE = 1,
     VK_ATTACHMENT_STORE_OP_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkBlendFactor  : int (int value)
+enum VkBlendFactor  : const int
 {
     VK_BLEND_FACTOR_ZERO = 0,
     VK_BLEND_FACTOR_ONE = 1,
@@ -115,7 +115,7 @@ enum VkBlendFactor  : int (int value)
     VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA = 18,
     VK_BLEND_FACTOR_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkBlendOp  : int (int value)
+enum VkBlendOp  : const int
 {
     VK_BLEND_OP_ADD = 0,
     VK_BLEND_OP_SUBTRACT = 1,
@@ -124,7 +124,7 @@ enum VkBlendOp  : int (int value)
     VK_BLEND_OP_MAX = 4,
     VK_BLEND_OP_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkBorderColor  : int (int value)
+enum VkBorderColor  : const int
 {
     VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK = 0,
     VK_BORDER_COLOR_INT_TRANSPARENT_BLACK = 1,
@@ -134,17 +134,17 @@ enum VkBorderColor  : int (int value)
     VK_BORDER_COLOR_INT_OPAQUE_WHITE = 5,
     VK_BORDER_COLOR_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPipelineCacheHeaderVersion  : int (int value)
+enum VkPipelineCacheHeaderVersion  : const int
 {
     VK_PIPELINE_CACHE_HEADER_VERSION_ONE = 1,
     VK_PIPELINE_CACHE_HEADER_VERSION_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDeviceQueueCreateFlagBits  : int (int value)
+enum VkDeviceQueueCreateFlagBits  : const int
 {
     VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT = 1,
     VK_DEVICE_QUEUE_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkBufferCreateFlagBits  : int (int value)
+enum VkBufferCreateFlagBits  : const int
 {
     VK_BUFFER_CREATE_SPARSE_BINDING_BIT = 1,
     VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT = 2,
@@ -152,7 +152,7 @@ enum VkBufferCreateFlagBits  : int (int value)
     VK_BUFFER_CREATE_PROTECTED_BIT = 8,
     VK_BUFFER_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkBufferUsageFlagBits  : int (int value)
+enum VkBufferUsageFlagBits  : const int
 {
     VK_BUFFER_USAGE_TRANSFER_SRC_BIT = 1,
     VK_BUFFER_USAGE_TRANSFER_DST_BIT = 2,
@@ -165,7 +165,7 @@ enum VkBufferUsageFlagBits  : int (int value)
     VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT = 256,
     VK_BUFFER_USAGE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkColorComponentFlagBits  : int (int value)
+enum VkColorComponentFlagBits  : const int
 {
     VK_COLOR_COMPONENT_R_BIT = 1,
     VK_COLOR_COMPONENT_G_BIT = 2,
@@ -173,7 +173,7 @@ enum VkColorComponentFlagBits  : int (int value)
     VK_COLOR_COMPONENT_A_BIT = 8,
     VK_COLOR_COMPONENT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkComponentSwizzle  : int (int value)
+enum VkComponentSwizzle  : const int
 {
     VK_COMPONENT_SWIZZLE_IDENTITY = 0,
     VK_COMPONENT_SWIZZLE_ZERO = 1,
@@ -184,37 +184,37 @@ enum VkComponentSwizzle  : int (int value)
     VK_COMPONENT_SWIZZLE_A = 6,
     VK_COMPONENT_SWIZZLE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCommandPoolCreateFlagBits  : int (int value)
+enum VkCommandPoolCreateFlagBits  : const int
 {
     VK_COMMAND_POOL_CREATE_TRANSIENT_BIT = 1,
     VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT = 2,
     VK_COMMAND_POOL_CREATE_PROTECTED_BIT = 4,
     VK_COMMAND_POOL_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCommandPoolResetFlagBits  : int (int value)
+enum VkCommandPoolResetFlagBits  : const int
 {
     VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT = 1,
     VK_COMMAND_POOL_RESET_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCommandBufferResetFlagBits  : int (int value)
+enum VkCommandBufferResetFlagBits  : const int
 {
     VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT = 1,
     VK_COMMAND_BUFFER_RESET_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCommandBufferLevel  : int (int value)
+enum VkCommandBufferLevel  : const int
 {
     VK_COMMAND_BUFFER_LEVEL_PRIMARY = 0,
     VK_COMMAND_BUFFER_LEVEL_SECONDARY = 1,
     VK_COMMAND_BUFFER_LEVEL_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCommandBufferUsageFlagBits  : int (int value)
+enum VkCommandBufferUsageFlagBits  : const int
 {
     VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT = 1,
     VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT = 2,
     VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT = 4,
     VK_COMMAND_BUFFER_USAGE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCompareOp  : int (int value)
+enum VkCompareOp  : const int
 {
     VK_COMPARE_OP_NEVER = 0,
     VK_COMPARE_OP_LESS = 1,
@@ -226,7 +226,7 @@ enum VkCompareOp  : int (int value)
     VK_COMPARE_OP_ALWAYS = 7,
     VK_COMPARE_OP_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCullModeFlagBits  : int (int value)
+enum VkCullModeFlagBits  : const int
 {
     VK_CULL_MODE_NONE = 0,
     VK_CULL_MODE_FRONT_BIT = 1,
@@ -234,7 +234,7 @@ enum VkCullModeFlagBits  : int (int value)
     VK_CULL_MODE_FRONT_AND_BACK = 0x00000003,
     VK_CULL_MODE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDescriptorType  : int (int value)
+enum VkDescriptorType  : const int
 {
     VK_DESCRIPTOR_TYPE_SAMPLER = 0,
     VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER = 1,
@@ -249,7 +249,7 @@ enum VkDescriptorType  : int (int value)
     VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT = 10,
     VK_DESCRIPTOR_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDynamicState  : int (int value)
+enum VkDynamicState  : const int
 {
     VK_DYNAMIC_STATE_VIEWPORT = 0,
     VK_DYNAMIC_STATE_SCISSOR = 1,
@@ -262,19 +262,19 @@ enum VkDynamicState  : int (int value)
     VK_DYNAMIC_STATE_STENCIL_REFERENCE = 8,
     VK_DYNAMIC_STATE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkFenceCreateFlagBits  : int (int value)
+enum VkFenceCreateFlagBits  : const int
 {
     VK_FENCE_CREATE_SIGNALED_BIT = 1,
     VK_FENCE_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPolygonMode  : int (int value)
+enum VkPolygonMode  : const int
 {
     VK_POLYGON_MODE_FILL = 0,
     VK_POLYGON_MODE_LINE = 1,
     VK_POLYGON_MODE_POINT = 2,
     VK_POLYGON_MODE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkFormat  : int (int value)
+enum VkFormat  : const int
 {
     VK_FORMAT_UNDEFINED = 0,
     VK_FORMAT_R4G4_UNORM_PACK8 = 1,
@@ -497,7 +497,7 @@ enum VkFormat  : int (int value)
     VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM = 1000156033,
     VK_FORMAT_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkFormatFeatureFlagBits  : int (int value)
+enum VkFormatFeatureFlagBits  : const int
 {
     VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT = 1,
     VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT = 2,
@@ -523,13 +523,13 @@ enum VkFormatFeatureFlagBits  : int (int value)
     VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT = 8388608,
     VK_FORMAT_FEATURE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkFrontFace  : int (int value)
+enum VkFrontFace  : const int
 {
     VK_FRONT_FACE_COUNTER_CLOCKWISE = 0,
     VK_FRONT_FACE_CLOCKWISE = 1,
     VK_FRONT_FACE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageAspectFlagBits  : int (int value)
+enum VkImageAspectFlagBits  : const int
 {
     VK_IMAGE_ASPECT_COLOR_BIT = 1,
     VK_IMAGE_ASPECT_DEPTH_BIT = 2,
@@ -540,7 +540,7 @@ enum VkImageAspectFlagBits  : int (int value)
     VK_IMAGE_ASPECT_PLANE_2_BIT = 64,
     VK_IMAGE_ASPECT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageCreateFlagBits  : int (int value)
+enum VkImageCreateFlagBits  : const int
 {
     VK_IMAGE_CREATE_SPARSE_BINDING_BIT = 1,
     VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT = 2,
@@ -556,7 +556,7 @@ enum VkImageCreateFlagBits  : int (int value)
     VK_IMAGE_CREATE_DISJOINT_BIT = 512,
     VK_IMAGE_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageLayout  : int (int value)
+enum VkImageLayout  : const int
 {
     VK_IMAGE_LAYOUT_UNDEFINED = 0,
     VK_IMAGE_LAYOUT_GENERAL = 1,
@@ -571,20 +571,20 @@ enum VkImageLayout  : int (int value)
     VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL = 1000117001,
     VK_IMAGE_LAYOUT_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageTiling  : int (int value)
+enum VkImageTiling  : const int
 {
     VK_IMAGE_TILING_OPTIMAL = 0,
     VK_IMAGE_TILING_LINEAR = 1,
     VK_IMAGE_TILING_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageType  : int (int value)
+enum VkImageType  : const int
 {
     VK_IMAGE_TYPE_1D = 0,
     VK_IMAGE_TYPE_2D = 1,
     VK_IMAGE_TYPE_3D = 2,
     VK_IMAGE_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageUsageFlagBits  : int (int value)
+enum VkImageUsageFlagBits  : const int
 {
     VK_IMAGE_USAGE_TRANSFER_SRC_BIT = 1,
     VK_IMAGE_USAGE_TRANSFER_DST_BIT = 2,
@@ -596,7 +596,7 @@ enum VkImageUsageFlagBits  : int (int value)
     VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT = 128,
     VK_IMAGE_USAGE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageViewType  : int (int value)
+enum VkImageViewType  : const int
 {
     VK_IMAGE_VIEW_TYPE_1D = 0,
     VK_IMAGE_VIEW_TYPE_2D = 1,
@@ -607,19 +607,19 @@ enum VkImageViewType  : int (int value)
     VK_IMAGE_VIEW_TYPE_CUBE_ARRAY = 6,
     VK_IMAGE_VIEW_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSharingMode  : int (int value)
+enum VkSharingMode  : const int
 {
     VK_SHARING_MODE_EXCLUSIVE = 0,
     VK_SHARING_MODE_CONCURRENT = 1,
     VK_SHARING_MODE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkIndexType  : int (int value)
+enum VkIndexType  : const int
 {
     VK_INDEX_TYPE_UINT16 = 0,
     VK_INDEX_TYPE_UINT32 = 1,
     VK_INDEX_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkLogicOp  : int (int value)
+enum VkLogicOp  : const int
 {
     VK_LOGIC_OP_CLEAR = 0,
     VK_LOGIC_OP_AND = 1,
@@ -639,13 +639,13 @@ enum VkLogicOp  : int (int value)
     VK_LOGIC_OP_SET = 15,
     VK_LOGIC_OP_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkMemoryHeapFlagBits  : int (int value)
+enum VkMemoryHeapFlagBits  : const int
 {
     VK_MEMORY_HEAP_DEVICE_LOCAL_BIT = 1,
     VK_MEMORY_HEAP_MULTI_INSTANCE_BIT = 2,
     VK_MEMORY_HEAP_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkAccessFlagBits  : int (int value)
+enum VkAccessFlagBits  : const int
 {
     VK_ACCESS_INDIRECT_COMMAND_READ_BIT = 1,
     VK_ACCESS_INDEX_READ_BIT = 2,
@@ -666,7 +666,7 @@ enum VkAccessFlagBits  : int (int value)
     VK_ACCESS_MEMORY_WRITE_BIT = 65536,
     VK_ACCESS_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkMemoryPropertyFlagBits  : int (int value)
+enum VkMemoryPropertyFlagBits  : const int
 {
     VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT = 1,
     VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT = 2,
@@ -676,7 +676,7 @@ enum VkMemoryPropertyFlagBits  : int (int value)
     VK_MEMORY_PROPERTY_PROTECTED_BIT = 32,
     VK_MEMORY_PROPERTY_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPhysicalDeviceType  : int (int value)
+enum VkPhysicalDeviceType  : const int
 {
     VK_PHYSICAL_DEVICE_TYPE_OTHER = 0,
     VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU = 1,
@@ -685,13 +685,13 @@ enum VkPhysicalDeviceType  : int (int value)
     VK_PHYSICAL_DEVICE_TYPE_CPU = 4,
     VK_PHYSICAL_DEVICE_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPipelineBindPoint  : int (int value)
+enum VkPipelineBindPoint  : const int
 {
     VK_PIPELINE_BIND_POINT_GRAPHICS = 0,
     VK_PIPELINE_BIND_POINT_COMPUTE = 1,
     VK_PIPELINE_BIND_POINT_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPipelineCreateFlagBits  : int (int value)
+enum VkPipelineCreateFlagBits  : const int
 {
     VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT = 1,
     VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT = 2,
@@ -701,7 +701,7 @@ enum VkPipelineCreateFlagBits  : int (int value)
     VK_PIPELINE_CREATE_DISPATCH_BASE = VK_PIPELINE_CREATE_DISPATCH_BASE_BIT,
     VK_PIPELINE_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPrimitiveTopology  : int (int value)
+enum VkPrimitiveTopology  : const int
 {
     VK_PRIMITIVE_TOPOLOGY_POINT_LIST = 0,
     VK_PRIMITIVE_TOPOLOGY_LINE_LIST = 1,
@@ -716,12 +716,12 @@ enum VkPrimitiveTopology  : int (int value)
     VK_PRIMITIVE_TOPOLOGY_PATCH_LIST = 10,
     VK_PRIMITIVE_TOPOLOGY_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkQueryControlFlagBits  : int (int value)
+enum VkQueryControlFlagBits  : const int
 {
     VK_QUERY_CONTROL_PRECISE_BIT = 1,
     VK_QUERY_CONTROL_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkQueryPipelineStatisticFlagBits  : int (int value)
+enum VkQueryPipelineStatisticFlagBits  : const int
 {
     VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT = 1,
     VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_PRIMITIVES_BIT = 2,
@@ -736,7 +736,7 @@ enum VkQueryPipelineStatisticFlagBits  : int (int value)
     VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT = 1024,
     VK_QUERY_PIPELINE_STATISTIC_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkQueryResultFlagBits  : int (int value)
+enum VkQueryResultFlagBits  : const int
 {
     VK_QUERY_RESULT_64_BIT = 1,
     VK_QUERY_RESULT_WAIT_BIT = 2,
@@ -744,14 +744,14 @@ enum VkQueryResultFlagBits  : int (int value)
     VK_QUERY_RESULT_PARTIAL_BIT = 8,
     VK_QUERY_RESULT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkQueryType  : int (int value)
+enum VkQueryType  : const int
 {
     VK_QUERY_TYPE_OCCLUSION = 0,
     VK_QUERY_TYPE_PIPELINE_STATISTICS = 1,
     VK_QUERY_TYPE_TIMESTAMP = 2,
     VK_QUERY_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkQueueFlagBits  : int (int value)
+enum VkQueueFlagBits  : const int
 {
     VK_QUEUE_GRAPHICS_BIT = 1,
     VK_QUEUE_COMPUTE_BIT = 2,
@@ -760,13 +760,13 @@ enum VkQueueFlagBits  : int (int value)
     VK_QUEUE_PROTECTED_BIT = 16,
     VK_QUEUE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSubpassContents  : int (int value)
+enum VkSubpassContents  : const int
 {
     VK_SUBPASS_CONTENTS_INLINE = 0,
     VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS = 1,
     VK_SUBPASS_CONTENTS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkResult  : int (int value)
+enum VkResult  : const int
 {
     VK_SUCCESS = 0,
     VK_NOT_READY = 1,
@@ -791,7 +791,7 @@ enum VkResult  : int (int value)
     VK_ERROR_INVALID_EXTERNAL_HANDLE = -1000072003,
     VK_RESULT_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkShaderStageFlagBits  : int (int value)
+enum VkShaderStageFlagBits  : const int
 {
     VK_SHADER_STAGE_VERTEX_BIT = 1,
     VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT = 2,
@@ -803,12 +803,12 @@ enum VkShaderStageFlagBits  : int (int value)
     VK_SHADER_STAGE_ALL = 0x7FFFFFFF,
     VK_SHADER_STAGE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSparseMemoryBindFlagBits  : int (int value)
+enum VkSparseMemoryBindFlagBits  : const int
 {
     VK_SPARSE_MEMORY_BIND_METADATA_BIT = 1,
     VK_SPARSE_MEMORY_BIND_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkStencilFaceFlagBits  : int (int value)
+enum VkStencilFaceFlagBits  : const int
 {
     VK_STENCIL_FACE_FRONT_BIT = 1,
     VK_STENCIL_FACE_BACK_BIT = 2,
@@ -816,7 +816,7 @@ enum VkStencilFaceFlagBits  : int (int value)
     VK_STENCIL_FRONT_AND_BACK = VK_STENCIL_FACE_FRONT_AND_BACK,
     VK_STENCIL_FACE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkStencilOp  : int (int value)
+enum VkStencilOp  : const int
 {
     VK_STENCIL_OP_KEEP = 0,
     VK_STENCIL_OP_ZERO = 1,
@@ -828,7 +828,7 @@ enum VkStencilOp  : int (int value)
     VK_STENCIL_OP_DECREMENT_AND_WRAP = 7,
     VK_STENCIL_OP_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkStructureType  : int (int value)
+enum VkStructureType  : const int
 {
     VK_STRUCTURE_TYPE_APPLICATION_INFO = 0,
     VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO = 1,
@@ -948,7 +948,7 @@ enum VkStructureType  : int (int value)
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETER_FEATURES = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES,
     VK_STRUCTURE_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSystemAllocationScope  : int (int value)
+enum VkSystemAllocationScope  : const int
 {
     VK_SYSTEM_ALLOCATION_SCOPE_COMMAND = 0,
     VK_SYSTEM_ALLOCATION_SCOPE_OBJECT = 1,
@@ -957,12 +957,12 @@ enum VkSystemAllocationScope  : int (int value)
     VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE = 4,
     VK_SYSTEM_ALLOCATION_SCOPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkInternalAllocationType  : int (int value)
+enum VkInternalAllocationType  : const int
 {
     VK_INTERNAL_ALLOCATION_TYPE_EXECUTABLE = 0,
     VK_INTERNAL_ALLOCATION_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSamplerAddressMode  : int (int value)
+enum VkSamplerAddressMode  : const int
 {
     VK_SAMPLER_ADDRESS_MODE_REPEAT = 0,
     VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT = 1,
@@ -970,25 +970,25 @@ enum VkSamplerAddressMode  : int (int value)
     VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER = 3,
     VK_SAMPLER_ADDRESS_MODE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkFilter  : int (int value)
+enum VkFilter  : const int
 {
     VK_FILTER_NEAREST = 0,
     VK_FILTER_LINEAR = 1,
     VK_FILTER_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSamplerMipmapMode  : int (int value)
+enum VkSamplerMipmapMode  : const int
 {
     VK_SAMPLER_MIPMAP_MODE_NEAREST = 0,
     VK_SAMPLER_MIPMAP_MODE_LINEAR = 1,
     VK_SAMPLER_MIPMAP_MODE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkVertexInputRate  : int (int value)
+enum VkVertexInputRate  : const int
 {
     VK_VERTEX_INPUT_RATE_VERTEX = 0,
     VK_VERTEX_INPUT_RATE_INSTANCE = 1,
     VK_VERTEX_INPUT_RATE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPipelineStageFlagBits  : int (int value)
+enum VkPipelineStageFlagBits  : const int
 {
     VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT = 1,
     VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT = 2,
@@ -1009,14 +1009,14 @@ enum VkPipelineStageFlagBits  : int (int value)
     VK_PIPELINE_STAGE_ALL_COMMANDS_BIT = 65536,
     VK_PIPELINE_STAGE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSparseImageFormatFlagBits  : int (int value)
+enum VkSparseImageFormatFlagBits  : const int
 {
     VK_SPARSE_IMAGE_FORMAT_SINGLE_MIPTAIL_BIT = 1,
     VK_SPARSE_IMAGE_FORMAT_ALIGNED_MIP_SIZE_BIT = 2,
     VK_SPARSE_IMAGE_FORMAT_NONSTANDARD_BLOCK_SIZE_BIT = 4,
     VK_SPARSE_IMAGE_FORMAT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSampleCountFlagBits  : int (int value)
+enum VkSampleCountFlagBits  : const int
 {
     VK_SAMPLE_COUNT_1_BIT = 1,
     VK_SAMPLE_COUNT_2_BIT = 2,
@@ -1027,24 +1027,24 @@ enum VkSampleCountFlagBits  : int (int value)
     VK_SAMPLE_COUNT_64_BIT = 64,
     VK_SAMPLE_COUNT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkAttachmentDescriptionFlagBits  : int (int value)
+enum VkAttachmentDescriptionFlagBits  : const int
 {
     VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT = 1,
     VK_ATTACHMENT_DESCRIPTION_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDescriptorPoolCreateFlagBits  : int (int value)
+enum VkDescriptorPoolCreateFlagBits  : const int
 {
     VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT = 1,
     VK_DESCRIPTOR_POOL_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDependencyFlagBits  : int (int value)
+enum VkDependencyFlagBits  : const int
 {
     VK_DEPENDENCY_BY_REGION_BIT = 1,
     VK_DEPENDENCY_DEVICE_GROUP_BIT = 4,
     VK_DEPENDENCY_VIEW_LOCAL_BIT = 2,
     VK_DEPENDENCY_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkObjectType  : int (int value)
+enum VkObjectType  : const int
 {
     VK_OBJECT_TYPE_UNKNOWN = 0,
     VK_OBJECT_TYPE_INSTANCE = 1,
@@ -1076,18 +1076,18 @@ enum VkObjectType  : int (int value)
     VK_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE = 1000085000,
     VK_OBJECT_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDescriptorUpdateTemplateType  : int (int value)
+enum VkDescriptorUpdateTemplateType  : const int
 {
     VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET = 0,
     VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPointClippingBehavior  : int (int value)
+enum VkPointClippingBehavior  : const int
 {
     VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES = 0,
     VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY = 1,
     VK_POINT_CLIPPING_BEHAVIOR_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkExternalMemoryHandleTypeFlagBits  : int (int value)
+enum VkExternalMemoryHandleTypeFlagBits  : const int
 {
     VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT = 1,
     VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT = 2,
@@ -1098,14 +1098,14 @@ enum VkExternalMemoryHandleTypeFlagBits  : int (int value)
     VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE_BIT = 64,
     VK_EXTERNAL_MEMORY_HANDLE_TYPE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkExternalMemoryFeatureFlagBits  : int (int value)
+enum VkExternalMemoryFeatureFlagBits  : const int
 {
     VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT = 1,
     VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT = 2,
     VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT = 4,
     VK_EXTERNAL_MEMORY_FEATURE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkExternalSemaphoreHandleTypeFlagBits  : int (int value)
+enum VkExternalSemaphoreHandleTypeFlagBits  : const int
 {
     VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT = 1,
     VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT = 2,
@@ -1115,18 +1115,18 @@ enum VkExternalSemaphoreHandleTypeFlagBits  : int (int value)
     VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT = 16,
     VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkExternalSemaphoreFeatureFlagBits  : int (int value)
+enum VkExternalSemaphoreFeatureFlagBits  : const int
 {
     VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT = 1,
     VK_EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE_BIT = 2,
     VK_EXTERNAL_SEMAPHORE_FEATURE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSemaphoreImportFlagBits  : int (int value)
+enum VkSemaphoreImportFlagBits  : const int
 {
     VK_SEMAPHORE_IMPORT_TEMPORARY_BIT = 1,
     VK_SEMAPHORE_IMPORT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkExternalFenceHandleTypeFlagBits  : int (int value)
+enum VkExternalFenceHandleTypeFlagBits  : const int
 {
     VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_FD_BIT = 1,
     VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_BIT = 2,
@@ -1134,18 +1134,18 @@ enum VkExternalFenceHandleTypeFlagBits  : int (int value)
     VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT = 8,
     VK_EXTERNAL_FENCE_HANDLE_TYPE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkExternalFenceFeatureFlagBits  : int (int value)
+enum VkExternalFenceFeatureFlagBits  : const int
 {
     VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT = 1,
     VK_EXTERNAL_FENCE_FEATURE_IMPORTABLE_BIT = 2,
     VK_EXTERNAL_FENCE_FEATURE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkFenceImportFlagBits  : int (int value)
+enum VkFenceImportFlagBits  : const int
 {
     VK_FENCE_IMPORT_TEMPORARY_BIT = 1,
     VK_FENCE_IMPORT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPeerMemoryFeatureFlagBits  : int (int value)
+enum VkPeerMemoryFeatureFlagBits  : const int
 {
     VK_PEER_MEMORY_FEATURE_COPY_SRC_BIT = 1,
     VK_PEER_MEMORY_FEATURE_COPY_DST_BIT = 2,
@@ -1153,12 +1153,12 @@ enum VkPeerMemoryFeatureFlagBits  : int (int value)
     VK_PEER_MEMORY_FEATURE_GENERIC_DST_BIT = 8,
     VK_PEER_MEMORY_FEATURE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkMemoryAllocateFlagBits  : int (int value)
+enum VkMemoryAllocateFlagBits  : const int
 {
     VK_MEMORY_ALLOCATE_DEVICE_MASK_BIT = 1,
     VK_MEMORY_ALLOCATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSubgroupFeatureFlagBits  : int (int value)
+enum VkSubgroupFeatureFlagBits  : const int
 {
     VK_SUBGROUP_FEATURE_BASIC_BIT = 1,
     VK_SUBGROUP_FEATURE_VOTE_BIT = 2,
@@ -1170,13 +1170,13 @@ enum VkSubgroupFeatureFlagBits  : int (int value)
     VK_SUBGROUP_FEATURE_QUAD_BIT = 128,
     VK_SUBGROUP_FEATURE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkTessellationDomainOrigin  : int (int value)
+enum VkTessellationDomainOrigin  : const int
 {
     VK_TESSELLATION_DOMAIN_ORIGIN_UPPER_LEFT = 0,
     VK_TESSELLATION_DOMAIN_ORIGIN_LOWER_LEFT = 1,
     VK_TESSELLATION_DOMAIN_ORIGIN_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSamplerYcbcrModelConversion  : int (int value)
+enum VkSamplerYcbcrModelConversion  : const int
 {
     VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY = 0,
     VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_IDENTITY = 1,
@@ -1185,19 +1185,19 @@ enum VkSamplerYcbcrModelConversion  : int (int value)
     VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020 = 4,
     VK_SAMPLER_YCBCR_MODEL_CONVERSION_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSamplerYcbcrRange  : int (int value)
+enum VkSamplerYcbcrRange  : const int
 {
     VK_SAMPLER_YCBCR_RANGE_ITU_FULL = 0,
     VK_SAMPLER_YCBCR_RANGE_ITU_NARROW = 1,
     VK_SAMPLER_YCBCR_RANGE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkChromaLocation  : int (int value)
+enum VkChromaLocation  : const int
 {
     VK_CHROMA_LOCATION_COSITED_EVEN = 0,
     VK_CHROMA_LOCATION_MIDPOINT = 1,
     VK_CHROMA_LOCATION_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkVendorId  : int (int value)
+enum VkVendorId  : const int
 {
     VK_VENDOR_ID_KHRONOS = 0x10000,
     VK_VENDOR_ID_VIV = 0x10001,

--- a/libraries/vulkan.c3l/vk12.c3i
+++ b/libraries/vulkan.c3l/vk12.c3i
@@ -79,20 +79,20 @@ typedef VkRenderPass = uptr;
 typedef VkPipelineCache = uptr;
 typedef VkDescriptorUpdateTemplate = uptr;
 typedef VkSamplerYcbcrConversion = uptr;
-enum VkAttachmentLoadOp  : int (int value)
+enum VkAttachmentLoadOp  : const int
 {
     VK_ATTACHMENT_LOAD_OP_LOAD = 0,
     VK_ATTACHMENT_LOAD_OP_CLEAR = 1,
     VK_ATTACHMENT_LOAD_OP_DONT_CARE = 2,
     VK_ATTACHMENT_LOAD_OP_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkAttachmentStoreOp  : int (int value)
+enum VkAttachmentStoreOp  : const int
 {
     VK_ATTACHMENT_STORE_OP_STORE = 0,
     VK_ATTACHMENT_STORE_OP_DONT_CARE = 1,
     VK_ATTACHMENT_STORE_OP_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkBlendFactor  : int (int value)
+enum VkBlendFactor  : const int
 {
     VK_BLEND_FACTOR_ZERO = 0,
     VK_BLEND_FACTOR_ONE = 1,
@@ -115,7 +115,7 @@ enum VkBlendFactor  : int (int value)
     VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA = 18,
     VK_BLEND_FACTOR_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkBlendOp  : int (int value)
+enum VkBlendOp  : const int
 {
     VK_BLEND_OP_ADD = 0,
     VK_BLEND_OP_SUBTRACT = 1,
@@ -124,7 +124,7 @@ enum VkBlendOp  : int (int value)
     VK_BLEND_OP_MAX = 4,
     VK_BLEND_OP_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkBorderColor  : int (int value)
+enum VkBorderColor  : const int
 {
     VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK = 0,
     VK_BORDER_COLOR_INT_TRANSPARENT_BLACK = 1,
@@ -134,27 +134,27 @@ enum VkBorderColor  : int (int value)
     VK_BORDER_COLOR_INT_OPAQUE_WHITE = 5,
     VK_BORDER_COLOR_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkFramebufferCreateFlagBits  : int (int value)
+enum VkFramebufferCreateFlagBits  : const int
 {
     VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT = 1,
     VK_FRAMEBUFFER_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPipelineCacheHeaderVersion  : int (int value)
+enum VkPipelineCacheHeaderVersion  : const int
 {
     VK_PIPELINE_CACHE_HEADER_VERSION_ONE = 1,
     VK_PIPELINE_CACHE_HEADER_VERSION_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDescriptorSetLayoutCreateFlagBits  : int (int value)
+enum VkDescriptorSetLayoutCreateFlagBits  : const int
 {
     VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT = 2,
     VK_DESCRIPTOR_SET_LAYOUT_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDeviceQueueCreateFlagBits  : int (int value)
+enum VkDeviceQueueCreateFlagBits  : const int
 {
     VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT = 1,
     VK_DEVICE_QUEUE_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkBufferCreateFlagBits  : int (int value)
+enum VkBufferCreateFlagBits  : const int
 {
     VK_BUFFER_CREATE_SPARSE_BINDING_BIT = 1,
     VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT = 2,
@@ -163,7 +163,7 @@ enum VkBufferCreateFlagBits  : int (int value)
     VK_BUFFER_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT = 16,
     VK_BUFFER_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkBufferUsageFlagBits  : int (int value)
+enum VkBufferUsageFlagBits  : const int
 {
     VK_BUFFER_USAGE_TRANSFER_SRC_BIT = 1,
     VK_BUFFER_USAGE_TRANSFER_DST_BIT = 2,
@@ -177,7 +177,7 @@ enum VkBufferUsageFlagBits  : int (int value)
     VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT = 131072,
     VK_BUFFER_USAGE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkColorComponentFlagBits  : int (int value)
+enum VkColorComponentFlagBits  : const int
 {
     VK_COLOR_COMPONENT_R_BIT = 1,
     VK_COLOR_COMPONENT_G_BIT = 2,
@@ -185,7 +185,7 @@ enum VkColorComponentFlagBits  : int (int value)
     VK_COLOR_COMPONENT_A_BIT = 8,
     VK_COLOR_COMPONENT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkComponentSwizzle  : int (int value)
+enum VkComponentSwizzle  : const int
 {
     VK_COMPONENT_SWIZZLE_IDENTITY = 0,
     VK_COMPONENT_SWIZZLE_ZERO = 1,
@@ -196,37 +196,37 @@ enum VkComponentSwizzle  : int (int value)
     VK_COMPONENT_SWIZZLE_A = 6,
     VK_COMPONENT_SWIZZLE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCommandPoolCreateFlagBits  : int (int value)
+enum VkCommandPoolCreateFlagBits  : const int
 {
     VK_COMMAND_POOL_CREATE_TRANSIENT_BIT = 1,
     VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT = 2,
     VK_COMMAND_POOL_CREATE_PROTECTED_BIT = 4,
     VK_COMMAND_POOL_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCommandPoolResetFlagBits  : int (int value)
+enum VkCommandPoolResetFlagBits  : const int
 {
     VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT = 1,
     VK_COMMAND_POOL_RESET_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCommandBufferResetFlagBits  : int (int value)
+enum VkCommandBufferResetFlagBits  : const int
 {
     VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT = 1,
     VK_COMMAND_BUFFER_RESET_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCommandBufferLevel  : int (int value)
+enum VkCommandBufferLevel  : const int
 {
     VK_COMMAND_BUFFER_LEVEL_PRIMARY = 0,
     VK_COMMAND_BUFFER_LEVEL_SECONDARY = 1,
     VK_COMMAND_BUFFER_LEVEL_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCommandBufferUsageFlagBits  : int (int value)
+enum VkCommandBufferUsageFlagBits  : const int
 {
     VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT = 1,
     VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT = 2,
     VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT = 4,
     VK_COMMAND_BUFFER_USAGE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCompareOp  : int (int value)
+enum VkCompareOp  : const int
 {
     VK_COMPARE_OP_NEVER = 0,
     VK_COMPARE_OP_LESS = 1,
@@ -238,7 +238,7 @@ enum VkCompareOp  : int (int value)
     VK_COMPARE_OP_ALWAYS = 7,
     VK_COMPARE_OP_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCullModeFlagBits  : int (int value)
+enum VkCullModeFlagBits  : const int
 {
     VK_CULL_MODE_NONE = 0,
     VK_CULL_MODE_FRONT_BIT = 1,
@@ -246,7 +246,7 @@ enum VkCullModeFlagBits  : int (int value)
     VK_CULL_MODE_FRONT_AND_BACK = 0x00000003,
     VK_CULL_MODE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDescriptorType  : int (int value)
+enum VkDescriptorType  : const int
 {
     VK_DESCRIPTOR_TYPE_SAMPLER = 0,
     VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER = 1,
@@ -261,7 +261,7 @@ enum VkDescriptorType  : int (int value)
     VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT = 10,
     VK_DESCRIPTOR_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDynamicState  : int (int value)
+enum VkDynamicState  : const int
 {
     VK_DYNAMIC_STATE_VIEWPORT = 0,
     VK_DYNAMIC_STATE_SCISSOR = 1,
@@ -274,19 +274,19 @@ enum VkDynamicState  : int (int value)
     VK_DYNAMIC_STATE_STENCIL_REFERENCE = 8,
     VK_DYNAMIC_STATE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkFenceCreateFlagBits  : int (int value)
+enum VkFenceCreateFlagBits  : const int
 {
     VK_FENCE_CREATE_SIGNALED_BIT = 1,
     VK_FENCE_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPolygonMode  : int (int value)
+enum VkPolygonMode  : const int
 {
     VK_POLYGON_MODE_FILL = 0,
     VK_POLYGON_MODE_LINE = 1,
     VK_POLYGON_MODE_POINT = 2,
     VK_POLYGON_MODE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkFormat  : int (int value)
+enum VkFormat  : const int
 {
     VK_FORMAT_UNDEFINED = 0,
     VK_FORMAT_R4G4_UNORM_PACK8 = 1,
@@ -509,7 +509,7 @@ enum VkFormat  : int (int value)
     VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM = 1000156033,
     VK_FORMAT_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkFormatFeatureFlagBits  : int (int value)
+enum VkFormatFeatureFlagBits  : const int
 {
     VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT = 1,
     VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT = 2,
@@ -536,13 +536,13 @@ enum VkFormatFeatureFlagBits  : int (int value)
     VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT = 65536,
     VK_FORMAT_FEATURE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkFrontFace  : int (int value)
+enum VkFrontFace  : const int
 {
     VK_FRONT_FACE_COUNTER_CLOCKWISE = 0,
     VK_FRONT_FACE_CLOCKWISE = 1,
     VK_FRONT_FACE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageAspectFlagBits  : int (int value)
+enum VkImageAspectFlagBits  : const int
 {
     VK_IMAGE_ASPECT_COLOR_BIT = 1,
     VK_IMAGE_ASPECT_DEPTH_BIT = 2,
@@ -553,7 +553,7 @@ enum VkImageAspectFlagBits  : int (int value)
     VK_IMAGE_ASPECT_PLANE_2_BIT = 64,
     VK_IMAGE_ASPECT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageCreateFlagBits  : int (int value)
+enum VkImageCreateFlagBits  : const int
 {
     VK_IMAGE_CREATE_SPARSE_BINDING_BIT = 1,
     VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT = 2,
@@ -569,7 +569,7 @@ enum VkImageCreateFlagBits  : int (int value)
     VK_IMAGE_CREATE_DISJOINT_BIT = 512,
     VK_IMAGE_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageLayout  : int (int value)
+enum VkImageLayout  : const int
 {
     VK_IMAGE_LAYOUT_UNDEFINED = 0,
     VK_IMAGE_LAYOUT_GENERAL = 1,
@@ -588,20 +588,20 @@ enum VkImageLayout  : int (int value)
     VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL = 1000241003,
     VK_IMAGE_LAYOUT_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageTiling  : int (int value)
+enum VkImageTiling  : const int
 {
     VK_IMAGE_TILING_OPTIMAL = 0,
     VK_IMAGE_TILING_LINEAR = 1,
     VK_IMAGE_TILING_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageType  : int (int value)
+enum VkImageType  : const int
 {
     VK_IMAGE_TYPE_1D = 0,
     VK_IMAGE_TYPE_2D = 1,
     VK_IMAGE_TYPE_3D = 2,
     VK_IMAGE_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageUsageFlagBits  : int (int value)
+enum VkImageUsageFlagBits  : const int
 {
     VK_IMAGE_USAGE_TRANSFER_SRC_BIT = 1,
     VK_IMAGE_USAGE_TRANSFER_DST_BIT = 2,
@@ -613,7 +613,7 @@ enum VkImageUsageFlagBits  : int (int value)
     VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT = 128,
     VK_IMAGE_USAGE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageViewType  : int (int value)
+enum VkImageViewType  : const int
 {
     VK_IMAGE_VIEW_TYPE_1D = 0,
     VK_IMAGE_VIEW_TYPE_2D = 1,
@@ -624,19 +624,19 @@ enum VkImageViewType  : int (int value)
     VK_IMAGE_VIEW_TYPE_CUBE_ARRAY = 6,
     VK_IMAGE_VIEW_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSharingMode  : int (int value)
+enum VkSharingMode  : const int
 {
     VK_SHARING_MODE_EXCLUSIVE = 0,
     VK_SHARING_MODE_CONCURRENT = 1,
     VK_SHARING_MODE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkIndexType  : int (int value)
+enum VkIndexType  : const int
 {
     VK_INDEX_TYPE_UINT16 = 0,
     VK_INDEX_TYPE_UINT32 = 1,
     VK_INDEX_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkLogicOp  : int (int value)
+enum VkLogicOp  : const int
 {
     VK_LOGIC_OP_CLEAR = 0,
     VK_LOGIC_OP_AND = 1,
@@ -656,13 +656,13 @@ enum VkLogicOp  : int (int value)
     VK_LOGIC_OP_SET = 15,
     VK_LOGIC_OP_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkMemoryHeapFlagBits  : int (int value)
+enum VkMemoryHeapFlagBits  : const int
 {
     VK_MEMORY_HEAP_DEVICE_LOCAL_BIT = 1,
     VK_MEMORY_HEAP_MULTI_INSTANCE_BIT = 2,
     VK_MEMORY_HEAP_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkAccessFlagBits  : int (int value)
+enum VkAccessFlagBits  : const int
 {
     VK_ACCESS_INDIRECT_COMMAND_READ_BIT = 1,
     VK_ACCESS_INDEX_READ_BIT = 2,
@@ -683,7 +683,7 @@ enum VkAccessFlagBits  : int (int value)
     VK_ACCESS_MEMORY_WRITE_BIT = 65536,
     VK_ACCESS_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkMemoryPropertyFlagBits  : int (int value)
+enum VkMemoryPropertyFlagBits  : const int
 {
     VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT = 1,
     VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT = 2,
@@ -693,7 +693,7 @@ enum VkMemoryPropertyFlagBits  : int (int value)
     VK_MEMORY_PROPERTY_PROTECTED_BIT = 32,
     VK_MEMORY_PROPERTY_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPhysicalDeviceType  : int (int value)
+enum VkPhysicalDeviceType  : const int
 {
     VK_PHYSICAL_DEVICE_TYPE_OTHER = 0,
     VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU = 1,
@@ -702,13 +702,13 @@ enum VkPhysicalDeviceType  : int (int value)
     VK_PHYSICAL_DEVICE_TYPE_CPU = 4,
     VK_PHYSICAL_DEVICE_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPipelineBindPoint  : int (int value)
+enum VkPipelineBindPoint  : const int
 {
     VK_PIPELINE_BIND_POINT_GRAPHICS = 0,
     VK_PIPELINE_BIND_POINT_COMPUTE = 1,
     VK_PIPELINE_BIND_POINT_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPipelineCreateFlagBits  : int (int value)
+enum VkPipelineCreateFlagBits  : const int
 {
     VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT = 1,
     VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT = 2,
@@ -718,7 +718,7 @@ enum VkPipelineCreateFlagBits  : int (int value)
     VK_PIPELINE_CREATE_DISPATCH_BASE = VK_PIPELINE_CREATE_DISPATCH_BASE_BIT,
     VK_PIPELINE_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPrimitiveTopology  : int (int value)
+enum VkPrimitiveTopology  : const int
 {
     VK_PRIMITIVE_TOPOLOGY_POINT_LIST = 0,
     VK_PRIMITIVE_TOPOLOGY_LINE_LIST = 1,
@@ -733,12 +733,12 @@ enum VkPrimitiveTopology  : int (int value)
     VK_PRIMITIVE_TOPOLOGY_PATCH_LIST = 10,
     VK_PRIMITIVE_TOPOLOGY_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkQueryControlFlagBits  : int (int value)
+enum VkQueryControlFlagBits  : const int
 {
     VK_QUERY_CONTROL_PRECISE_BIT = 1,
     VK_QUERY_CONTROL_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkQueryPipelineStatisticFlagBits  : int (int value)
+enum VkQueryPipelineStatisticFlagBits  : const int
 {
     VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT = 1,
     VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_PRIMITIVES_BIT = 2,
@@ -753,7 +753,7 @@ enum VkQueryPipelineStatisticFlagBits  : int (int value)
     VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT = 1024,
     VK_QUERY_PIPELINE_STATISTIC_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkQueryResultFlagBits  : int (int value)
+enum VkQueryResultFlagBits  : const int
 {
     VK_QUERY_RESULT_64_BIT = 1,
     VK_QUERY_RESULT_WAIT_BIT = 2,
@@ -761,14 +761,14 @@ enum VkQueryResultFlagBits  : int (int value)
     VK_QUERY_RESULT_PARTIAL_BIT = 8,
     VK_QUERY_RESULT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkQueryType  : int (int value)
+enum VkQueryType  : const int
 {
     VK_QUERY_TYPE_OCCLUSION = 0,
     VK_QUERY_TYPE_PIPELINE_STATISTICS = 1,
     VK_QUERY_TYPE_TIMESTAMP = 2,
     VK_QUERY_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkQueueFlagBits  : int (int value)
+enum VkQueueFlagBits  : const int
 {
     VK_QUEUE_GRAPHICS_BIT = 1,
     VK_QUEUE_COMPUTE_BIT = 2,
@@ -777,13 +777,13 @@ enum VkQueueFlagBits  : int (int value)
     VK_QUEUE_PROTECTED_BIT = 16,
     VK_QUEUE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSubpassContents  : int (int value)
+enum VkSubpassContents  : const int
 {
     VK_SUBPASS_CONTENTS_INLINE = 0,
     VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS = 1,
     VK_SUBPASS_CONTENTS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkResult  : int (int value)
+enum VkResult  : const int
 {
     VK_SUCCESS = 0,
     VK_NOT_READY = 1,
@@ -810,7 +810,7 @@ enum VkResult  : int (int value)
     VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS = -1000257000,
     VK_RESULT_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkShaderStageFlagBits  : int (int value)
+enum VkShaderStageFlagBits  : const int
 {
     VK_SHADER_STAGE_VERTEX_BIT = 1,
     VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT = 2,
@@ -822,12 +822,12 @@ enum VkShaderStageFlagBits  : int (int value)
     VK_SHADER_STAGE_ALL = 0x7FFFFFFF,
     VK_SHADER_STAGE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSparseMemoryBindFlagBits  : int (int value)
+enum VkSparseMemoryBindFlagBits  : const int
 {
     VK_SPARSE_MEMORY_BIND_METADATA_BIT = 1,
     VK_SPARSE_MEMORY_BIND_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkStencilFaceFlagBits  : int (int value)
+enum VkStencilFaceFlagBits  : const int
 {
     VK_STENCIL_FACE_FRONT_BIT = 1,
     VK_STENCIL_FACE_BACK_BIT = 2,
@@ -835,7 +835,7 @@ enum VkStencilFaceFlagBits  : int (int value)
     VK_STENCIL_FRONT_AND_BACK = VK_STENCIL_FACE_FRONT_AND_BACK,
     VK_STENCIL_FACE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkStencilOp  : int (int value)
+enum VkStencilOp  : const int
 {
     VK_STENCIL_OP_KEEP = 0,
     VK_STENCIL_OP_ZERO = 1,
@@ -847,7 +847,7 @@ enum VkStencilOp  : int (int value)
     VK_STENCIL_OP_DECREMENT_AND_WRAP = 7,
     VK_STENCIL_OP_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkStructureType  : int (int value)
+enum VkStructureType  : const int
 {
     VK_STRUCTURE_TYPE_APPLICATION_INFO = 0,
     VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO = 1,
@@ -1017,7 +1017,7 @@ enum VkStructureType  : int (int value)
     VK_STRUCTURE_TYPE_DEVICE_MEMORY_OPAQUE_CAPTURE_ADDRESS_INFO = 1000257004,
     VK_STRUCTURE_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSystemAllocationScope  : int (int value)
+enum VkSystemAllocationScope  : const int
 {
     VK_SYSTEM_ALLOCATION_SCOPE_COMMAND = 0,
     VK_SYSTEM_ALLOCATION_SCOPE_OBJECT = 1,
@@ -1026,12 +1026,12 @@ enum VkSystemAllocationScope  : int (int value)
     VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE = 4,
     VK_SYSTEM_ALLOCATION_SCOPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkInternalAllocationType  : int (int value)
+enum VkInternalAllocationType  : const int
 {
     VK_INTERNAL_ALLOCATION_TYPE_EXECUTABLE = 0,
     VK_INTERNAL_ALLOCATION_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSamplerAddressMode  : int (int value)
+enum VkSamplerAddressMode  : const int
 {
     VK_SAMPLER_ADDRESS_MODE_REPEAT = 0,
     VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT = 1,
@@ -1040,25 +1040,25 @@ enum VkSamplerAddressMode  : int (int value)
     VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE = 4,
     VK_SAMPLER_ADDRESS_MODE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkFilter  : int (int value)
+enum VkFilter  : const int
 {
     VK_FILTER_NEAREST = 0,
     VK_FILTER_LINEAR = 1,
     VK_FILTER_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSamplerMipmapMode  : int (int value)
+enum VkSamplerMipmapMode  : const int
 {
     VK_SAMPLER_MIPMAP_MODE_NEAREST = 0,
     VK_SAMPLER_MIPMAP_MODE_LINEAR = 1,
     VK_SAMPLER_MIPMAP_MODE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkVertexInputRate  : int (int value)
+enum VkVertexInputRate  : const int
 {
     VK_VERTEX_INPUT_RATE_VERTEX = 0,
     VK_VERTEX_INPUT_RATE_INSTANCE = 1,
     VK_VERTEX_INPUT_RATE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPipelineStageFlagBits  : int (int value)
+enum VkPipelineStageFlagBits  : const int
 {
     VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT = 1,
     VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT = 2,
@@ -1079,14 +1079,14 @@ enum VkPipelineStageFlagBits  : int (int value)
     VK_PIPELINE_STAGE_ALL_COMMANDS_BIT = 65536,
     VK_PIPELINE_STAGE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSparseImageFormatFlagBits  : int (int value)
+enum VkSparseImageFormatFlagBits  : const int
 {
     VK_SPARSE_IMAGE_FORMAT_SINGLE_MIPTAIL_BIT = 1,
     VK_SPARSE_IMAGE_FORMAT_ALIGNED_MIP_SIZE_BIT = 2,
     VK_SPARSE_IMAGE_FORMAT_NONSTANDARD_BLOCK_SIZE_BIT = 4,
     VK_SPARSE_IMAGE_FORMAT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSampleCountFlagBits  : int (int value)
+enum VkSampleCountFlagBits  : const int
 {
     VK_SAMPLE_COUNT_1_BIT = 1,
     VK_SAMPLE_COUNT_2_BIT = 2,
@@ -1097,25 +1097,25 @@ enum VkSampleCountFlagBits  : int (int value)
     VK_SAMPLE_COUNT_64_BIT = 64,
     VK_SAMPLE_COUNT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkAttachmentDescriptionFlagBits  : int (int value)
+enum VkAttachmentDescriptionFlagBits  : const int
 {
     VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT = 1,
     VK_ATTACHMENT_DESCRIPTION_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDescriptorPoolCreateFlagBits  : int (int value)
+enum VkDescriptorPoolCreateFlagBits  : const int
 {
     VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT = 1,
     VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT = 2,
     VK_DESCRIPTOR_POOL_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDependencyFlagBits  : int (int value)
+enum VkDependencyFlagBits  : const int
 {
     VK_DEPENDENCY_BY_REGION_BIT = 1,
     VK_DEPENDENCY_DEVICE_GROUP_BIT = 4,
     VK_DEPENDENCY_VIEW_LOCAL_BIT = 2,
     VK_DEPENDENCY_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkObjectType  : int (int value)
+enum VkObjectType  : const int
 {
     VK_OBJECT_TYPE_UNKNOWN = 0,
     VK_OBJECT_TYPE_INSTANCE = 1,
@@ -1147,18 +1147,18 @@ enum VkObjectType  : int (int value)
     VK_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE = 1000085000,
     VK_OBJECT_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDescriptorUpdateTemplateType  : int (int value)
+enum VkDescriptorUpdateTemplateType  : const int
 {
     VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET = 0,
     VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPointClippingBehavior  : int (int value)
+enum VkPointClippingBehavior  : const int
 {
     VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES = 0,
     VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY = 1,
     VK_POINT_CLIPPING_BEHAVIOR_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkResolveModeFlagBits  : int (int value)
+enum VkResolveModeFlagBits  : const int
 {
     VK_RESOLVE_MODE_NONE = 0,
     VK_RESOLVE_MODE_SAMPLE_ZERO_BIT = 1,
@@ -1167,7 +1167,7 @@ enum VkResolveModeFlagBits  : int (int value)
     VK_RESOLVE_MODE_MAX_BIT = 8,
     VK_RESOLVE_MODE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDescriptorBindingFlagBits  : int (int value)
+enum VkDescriptorBindingFlagBits  : const int
 {
     VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT = 1,
     VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT = 2,
@@ -1175,18 +1175,18 @@ enum VkDescriptorBindingFlagBits  : int (int value)
     VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT = 8,
     VK_DESCRIPTOR_BINDING_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSemaphoreType  : int (int value)
+enum VkSemaphoreType  : const int
 {
     VK_SEMAPHORE_TYPE_BINARY = 0,
     VK_SEMAPHORE_TYPE_TIMELINE = 1,
     VK_SEMAPHORE_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSemaphoreWaitFlagBits  : int (int value)
+enum VkSemaphoreWaitFlagBits  : const int
 {
     VK_SEMAPHORE_WAIT_ANY_BIT = 1,
     VK_SEMAPHORE_WAIT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkExternalMemoryHandleTypeFlagBits  : int (int value)
+enum VkExternalMemoryHandleTypeFlagBits  : const int
 {
     VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT = 1,
     VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT = 2,
@@ -1197,14 +1197,14 @@ enum VkExternalMemoryHandleTypeFlagBits  : int (int value)
     VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE_BIT = 64,
     VK_EXTERNAL_MEMORY_HANDLE_TYPE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkExternalMemoryFeatureFlagBits  : int (int value)
+enum VkExternalMemoryFeatureFlagBits  : const int
 {
     VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT = 1,
     VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT = 2,
     VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT = 4,
     VK_EXTERNAL_MEMORY_FEATURE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkExternalSemaphoreHandleTypeFlagBits  : int (int value)
+enum VkExternalSemaphoreHandleTypeFlagBits  : const int
 {
     VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT = 1,
     VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT = 2,
@@ -1214,18 +1214,18 @@ enum VkExternalSemaphoreHandleTypeFlagBits  : int (int value)
     VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT = 16,
     VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkExternalSemaphoreFeatureFlagBits  : int (int value)
+enum VkExternalSemaphoreFeatureFlagBits  : const int
 {
     VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT = 1,
     VK_EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE_BIT = 2,
     VK_EXTERNAL_SEMAPHORE_FEATURE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSemaphoreImportFlagBits  : int (int value)
+enum VkSemaphoreImportFlagBits  : const int
 {
     VK_SEMAPHORE_IMPORT_TEMPORARY_BIT = 1,
     VK_SEMAPHORE_IMPORT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkExternalFenceHandleTypeFlagBits  : int (int value)
+enum VkExternalFenceHandleTypeFlagBits  : const int
 {
     VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_FD_BIT = 1,
     VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_BIT = 2,
@@ -1233,18 +1233,18 @@ enum VkExternalFenceHandleTypeFlagBits  : int (int value)
     VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT = 8,
     VK_EXTERNAL_FENCE_HANDLE_TYPE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkExternalFenceFeatureFlagBits  : int (int value)
+enum VkExternalFenceFeatureFlagBits  : const int
 {
     VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT = 1,
     VK_EXTERNAL_FENCE_FEATURE_IMPORTABLE_BIT = 2,
     VK_EXTERNAL_FENCE_FEATURE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkFenceImportFlagBits  : int (int value)
+enum VkFenceImportFlagBits  : const int
 {
     VK_FENCE_IMPORT_TEMPORARY_BIT = 1,
     VK_FENCE_IMPORT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPeerMemoryFeatureFlagBits  : int (int value)
+enum VkPeerMemoryFeatureFlagBits  : const int
 {
     VK_PEER_MEMORY_FEATURE_COPY_SRC_BIT = 1,
     VK_PEER_MEMORY_FEATURE_COPY_DST_BIT = 2,
@@ -1252,14 +1252,14 @@ enum VkPeerMemoryFeatureFlagBits  : int (int value)
     VK_PEER_MEMORY_FEATURE_GENERIC_DST_BIT = 8,
     VK_PEER_MEMORY_FEATURE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkMemoryAllocateFlagBits  : int (int value)
+enum VkMemoryAllocateFlagBits  : const int
 {
     VK_MEMORY_ALLOCATE_DEVICE_MASK_BIT = 1,
     VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT = 2,
     VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT = 4,
     VK_MEMORY_ALLOCATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSubgroupFeatureFlagBits  : int (int value)
+enum VkSubgroupFeatureFlagBits  : const int
 {
     VK_SUBGROUP_FEATURE_BASIC_BIT = 1,
     VK_SUBGROUP_FEATURE_VOTE_BIT = 2,
@@ -1271,13 +1271,13 @@ enum VkSubgroupFeatureFlagBits  : int (int value)
     VK_SUBGROUP_FEATURE_QUAD_BIT = 128,
     VK_SUBGROUP_FEATURE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkTessellationDomainOrigin  : int (int value)
+enum VkTessellationDomainOrigin  : const int
 {
     VK_TESSELLATION_DOMAIN_ORIGIN_UPPER_LEFT = 0,
     VK_TESSELLATION_DOMAIN_ORIGIN_LOWER_LEFT = 1,
     VK_TESSELLATION_DOMAIN_ORIGIN_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSamplerYcbcrModelConversion  : int (int value)
+enum VkSamplerYcbcrModelConversion  : const int
 {
     VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY = 0,
     VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_IDENTITY = 1,
@@ -1286,33 +1286,33 @@ enum VkSamplerYcbcrModelConversion  : int (int value)
     VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020 = 4,
     VK_SAMPLER_YCBCR_MODEL_CONVERSION_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSamplerYcbcrRange  : int (int value)
+enum VkSamplerYcbcrRange  : const int
 {
     VK_SAMPLER_YCBCR_RANGE_ITU_FULL = 0,
     VK_SAMPLER_YCBCR_RANGE_ITU_NARROW = 1,
     VK_SAMPLER_YCBCR_RANGE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkChromaLocation  : int (int value)
+enum VkChromaLocation  : const int
 {
     VK_CHROMA_LOCATION_COSITED_EVEN = 0,
     VK_CHROMA_LOCATION_MIDPOINT = 1,
     VK_CHROMA_LOCATION_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSamplerReductionMode  : int (int value)
+enum VkSamplerReductionMode  : const int
 {
     VK_SAMPLER_REDUCTION_MODE_WEIGHTED_AVERAGE = 0,
     VK_SAMPLER_REDUCTION_MODE_MIN = 1,
     VK_SAMPLER_REDUCTION_MODE_MAX = 2,
     VK_SAMPLER_REDUCTION_MODE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkShaderFloatControlsIndependence  : int (int value)
+enum VkShaderFloatControlsIndependence  : const int
 {
     VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY = 0,
     VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL = 1,
     VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE = 2,
     VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkVendorId  : int (int value)
+enum VkVendorId  : const int
 {
     VK_VENDOR_ID_KHRONOS = 0x10000,
     VK_VENDOR_ID_VIV = 0x10001,
@@ -1324,7 +1324,7 @@ enum VkVendorId  : int (int value)
     VK_VENDOR_ID_MOBILEYE = 0x10007,
     VK_VENDOR_ID_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDriverId  : int (int value)
+enum VkDriverId  : const int
 {
     VK_DRIVER_ID_AMD_PROPRIETARY = 1,
     VK_DRIVER_ID_AMD_OPEN_SOURCE = 2,

--- a/libraries/vulkan.c3l/vk13.c3i
+++ b/libraries/vulkan.c3l/vk13.c3i
@@ -79,21 +79,21 @@ typedef VkPipelineCache = uptr;
 typedef VkDescriptorUpdateTemplate = uptr;
 typedef VkSamplerYcbcrConversion = uptr;
 typedef VkPrivateDataSlot = uptr;
-enum VkAttachmentLoadOp  : int (int value)
+enum VkAttachmentLoadOp  : const int
 {
     VK_ATTACHMENT_LOAD_OP_LOAD = 0,
     VK_ATTACHMENT_LOAD_OP_CLEAR = 1,
     VK_ATTACHMENT_LOAD_OP_DONT_CARE = 2,
     VK_ATTACHMENT_LOAD_OP_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkAttachmentStoreOp  : int (int value)
+enum VkAttachmentStoreOp  : const int
 {
     VK_ATTACHMENT_STORE_OP_STORE = 0,
     VK_ATTACHMENT_STORE_OP_DONT_CARE = 1,
     VK_ATTACHMENT_STORE_OP_NONE = 1000301000,
     VK_ATTACHMENT_STORE_OP_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkBlendFactor  : int (int value)
+enum VkBlendFactor  : const int
 {
     VK_BLEND_FACTOR_ZERO = 0,
     VK_BLEND_FACTOR_ONE = 1,
@@ -116,7 +116,7 @@ enum VkBlendFactor  : int (int value)
     VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA = 18,
     VK_BLEND_FACTOR_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkBlendOp  : int (int value)
+enum VkBlendOp  : const int
 {
     VK_BLEND_OP_ADD = 0,
     VK_BLEND_OP_SUBTRACT = 1,
@@ -125,7 +125,7 @@ enum VkBlendOp  : int (int value)
     VK_BLEND_OP_MAX = 4,
     VK_BLEND_OP_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkBorderColor  : int (int value)
+enum VkBorderColor  : const int
 {
     VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK = 0,
     VK_BORDER_COLOR_INT_TRANSPARENT_BLACK = 1,
@@ -135,38 +135,38 @@ enum VkBorderColor  : int (int value)
     VK_BORDER_COLOR_INT_OPAQUE_WHITE = 5,
     VK_BORDER_COLOR_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkFramebufferCreateFlagBits  : int (int value)
+enum VkFramebufferCreateFlagBits  : const int
 {
     VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT = 1,
     VK_FRAMEBUFFER_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPipelineCacheHeaderVersion  : int (int value)
+enum VkPipelineCacheHeaderVersion  : const int
 {
     VK_PIPELINE_CACHE_HEADER_VERSION_ONE = 1,
     VK_PIPELINE_CACHE_HEADER_VERSION_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPipelineCacheCreateFlagBits  : int (int value)
+enum VkPipelineCacheCreateFlagBits  : const int
 {
     VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT = 1,
     VK_PIPELINE_CACHE_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPipelineShaderStageCreateFlagBits  : int (int value)
+enum VkPipelineShaderStageCreateFlagBits  : const int
 {
     VK_PIPELINE_SHADER_STAGE_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT = 1,
     VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT = 2,
     VK_PIPELINE_SHADER_STAGE_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDescriptorSetLayoutCreateFlagBits  : int (int value)
+enum VkDescriptorSetLayoutCreateFlagBits  : const int
 {
     VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT = 2,
     VK_DESCRIPTOR_SET_LAYOUT_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDeviceQueueCreateFlagBits  : int (int value)
+enum VkDeviceQueueCreateFlagBits  : const int
 {
     VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT = 1,
     VK_DEVICE_QUEUE_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkBufferCreateFlagBits  : int (int value)
+enum VkBufferCreateFlagBits  : const int
 {
     VK_BUFFER_CREATE_SPARSE_BINDING_BIT = 1,
     VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT = 2,
@@ -175,7 +175,7 @@ enum VkBufferCreateFlagBits  : int (int value)
     VK_BUFFER_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT = 16,
     VK_BUFFER_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkBufferUsageFlagBits  : int (int value)
+enum VkBufferUsageFlagBits  : const int
 {
     VK_BUFFER_USAGE_TRANSFER_SRC_BIT = 1,
     VK_BUFFER_USAGE_TRANSFER_DST_BIT = 2,
@@ -189,7 +189,7 @@ enum VkBufferUsageFlagBits  : int (int value)
     VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT = 131072,
     VK_BUFFER_USAGE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkColorComponentFlagBits  : int (int value)
+enum VkColorComponentFlagBits  : const int
 {
     VK_COLOR_COMPONENT_R_BIT = 1,
     VK_COLOR_COMPONENT_G_BIT = 2,
@@ -197,7 +197,7 @@ enum VkColorComponentFlagBits  : int (int value)
     VK_COLOR_COMPONENT_A_BIT = 8,
     VK_COLOR_COMPONENT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkComponentSwizzle  : int (int value)
+enum VkComponentSwizzle  : const int
 {
     VK_COMPONENT_SWIZZLE_IDENTITY = 0,
     VK_COMPONENT_SWIZZLE_ZERO = 1,
@@ -208,37 +208,37 @@ enum VkComponentSwizzle  : int (int value)
     VK_COMPONENT_SWIZZLE_A = 6,
     VK_COMPONENT_SWIZZLE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCommandPoolCreateFlagBits  : int (int value)
+enum VkCommandPoolCreateFlagBits  : const int
 {
     VK_COMMAND_POOL_CREATE_TRANSIENT_BIT = 1,
     VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT = 2,
     VK_COMMAND_POOL_CREATE_PROTECTED_BIT = 4,
     VK_COMMAND_POOL_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCommandPoolResetFlagBits  : int (int value)
+enum VkCommandPoolResetFlagBits  : const int
 {
     VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT = 1,
     VK_COMMAND_POOL_RESET_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCommandBufferResetFlagBits  : int (int value)
+enum VkCommandBufferResetFlagBits  : const int
 {
     VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT = 1,
     VK_COMMAND_BUFFER_RESET_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCommandBufferLevel  : int (int value)
+enum VkCommandBufferLevel  : const int
 {
     VK_COMMAND_BUFFER_LEVEL_PRIMARY = 0,
     VK_COMMAND_BUFFER_LEVEL_SECONDARY = 1,
     VK_COMMAND_BUFFER_LEVEL_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCommandBufferUsageFlagBits  : int (int value)
+enum VkCommandBufferUsageFlagBits  : const int
 {
     VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT = 1,
     VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT = 2,
     VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT = 4,
     VK_COMMAND_BUFFER_USAGE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCompareOp  : int (int value)
+enum VkCompareOp  : const int
 {
     VK_COMPARE_OP_NEVER = 0,
     VK_COMPARE_OP_LESS = 1,
@@ -250,7 +250,7 @@ enum VkCompareOp  : int (int value)
     VK_COMPARE_OP_ALWAYS = 7,
     VK_COMPARE_OP_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkCullModeFlagBits  : int (int value)
+enum VkCullModeFlagBits  : const int
 {
     VK_CULL_MODE_NONE = 0,
     VK_CULL_MODE_FRONT_BIT = 1,
@@ -258,7 +258,7 @@ enum VkCullModeFlagBits  : int (int value)
     VK_CULL_MODE_FRONT_AND_BACK = 0x00000003,
     VK_CULL_MODE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDescriptorType  : int (int value)
+enum VkDescriptorType  : const int
 {
     VK_DESCRIPTOR_TYPE_SAMPLER = 0,
     VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER = 1,
@@ -274,7 +274,7 @@ enum VkDescriptorType  : int (int value)
     VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK = 1000138000,
     VK_DESCRIPTOR_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDynamicState  : int (int value)
+enum VkDynamicState  : const int
 {
     VK_DYNAMIC_STATE_VIEWPORT = 0,
     VK_DYNAMIC_STATE_SCISSOR = 1,
@@ -302,19 +302,19 @@ enum VkDynamicState  : int (int value)
     VK_DYNAMIC_STATE_PRIMITIVE_RESTART_ENABLE = 1000377004,
     VK_DYNAMIC_STATE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkFenceCreateFlagBits  : int (int value)
+enum VkFenceCreateFlagBits  : const int
 {
     VK_FENCE_CREATE_SIGNALED_BIT = 1,
     VK_FENCE_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPolygonMode  : int (int value)
+enum VkPolygonMode  : const int
 {
     VK_POLYGON_MODE_FILL = 0,
     VK_POLYGON_MODE_LINE = 1,
     VK_POLYGON_MODE_POINT = 2,
     VK_POLYGON_MODE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkFormat  : int (int value)
+enum VkFormat  : const int
 {
     VK_FORMAT_UNDEFINED = 0,
     VK_FORMAT_R4G4_UNORM_PACK8 = 1,
@@ -557,7 +557,7 @@ enum VkFormat  : int (int value)
     VK_FORMAT_ASTC_12X12_SFLOAT_BLOCK = 1000066013,
     VK_FORMAT_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkFormatFeatureFlagBits  : int (int value)
+enum VkFormatFeatureFlagBits  : const int
 {
     VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT = 1,
     VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT = 2,
@@ -584,13 +584,13 @@ enum VkFormatFeatureFlagBits  : int (int value)
     VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT = 65536,
     VK_FORMAT_FEATURE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkFrontFace  : int (int value)
+enum VkFrontFace  : const int
 {
     VK_FRONT_FACE_COUNTER_CLOCKWISE = 0,
     VK_FRONT_FACE_CLOCKWISE = 1,
     VK_FRONT_FACE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageAspectFlagBits  : int (int value)
+enum VkImageAspectFlagBits  : const int
 {
     VK_IMAGE_ASPECT_COLOR_BIT = 1,
     VK_IMAGE_ASPECT_DEPTH_BIT = 2,
@@ -602,7 +602,7 @@ enum VkImageAspectFlagBits  : int (int value)
     VK_IMAGE_ASPECT_NONE = 0,
     VK_IMAGE_ASPECT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageCreateFlagBits  : int (int value)
+enum VkImageCreateFlagBits  : const int
 {
     VK_IMAGE_CREATE_SPARSE_BINDING_BIT = 1,
     VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT = 2,
@@ -618,7 +618,7 @@ enum VkImageCreateFlagBits  : int (int value)
     VK_IMAGE_CREATE_DISJOINT_BIT = 512,
     VK_IMAGE_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageLayout  : int (int value)
+enum VkImageLayout  : const int
 {
     VK_IMAGE_LAYOUT_UNDEFINED = 0,
     VK_IMAGE_LAYOUT_GENERAL = 1,
@@ -639,20 +639,20 @@ enum VkImageLayout  : int (int value)
     VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL = 1000314001,
     VK_IMAGE_LAYOUT_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageTiling  : int (int value)
+enum VkImageTiling  : const int
 {
     VK_IMAGE_TILING_OPTIMAL = 0,
     VK_IMAGE_TILING_LINEAR = 1,
     VK_IMAGE_TILING_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageType  : int (int value)
+enum VkImageType  : const int
 {
     VK_IMAGE_TYPE_1D = 0,
     VK_IMAGE_TYPE_2D = 1,
     VK_IMAGE_TYPE_3D = 2,
     VK_IMAGE_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageUsageFlagBits  : int (int value)
+enum VkImageUsageFlagBits  : const int
 {
     VK_IMAGE_USAGE_TRANSFER_SRC_BIT = 1,
     VK_IMAGE_USAGE_TRANSFER_DST_BIT = 2,
@@ -664,7 +664,7 @@ enum VkImageUsageFlagBits  : int (int value)
     VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT = 128,
     VK_IMAGE_USAGE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkImageViewType  : int (int value)
+enum VkImageViewType  : const int
 {
     VK_IMAGE_VIEW_TYPE_1D = 0,
     VK_IMAGE_VIEW_TYPE_2D = 1,
@@ -675,19 +675,19 @@ enum VkImageViewType  : int (int value)
     VK_IMAGE_VIEW_TYPE_CUBE_ARRAY = 6,
     VK_IMAGE_VIEW_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSharingMode  : int (int value)
+enum VkSharingMode  : const int
 {
     VK_SHARING_MODE_EXCLUSIVE = 0,
     VK_SHARING_MODE_CONCURRENT = 1,
     VK_SHARING_MODE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkIndexType  : int (int value)
+enum VkIndexType  : const int
 {
     VK_INDEX_TYPE_UINT16 = 0,
     VK_INDEX_TYPE_UINT32 = 1,
     VK_INDEX_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkLogicOp  : int (int value)
+enum VkLogicOp  : const int
 {
     VK_LOGIC_OP_CLEAR = 0,
     VK_LOGIC_OP_AND = 1,
@@ -707,13 +707,13 @@ enum VkLogicOp  : int (int value)
     VK_LOGIC_OP_SET = 15,
     VK_LOGIC_OP_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkMemoryHeapFlagBits  : int (int value)
+enum VkMemoryHeapFlagBits  : const int
 {
     VK_MEMORY_HEAP_DEVICE_LOCAL_BIT = 1,
     VK_MEMORY_HEAP_MULTI_INSTANCE_BIT = 2,
     VK_MEMORY_HEAP_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkAccessFlagBits  : int (int value)
+enum VkAccessFlagBits  : const int
 {
     VK_ACCESS_INDIRECT_COMMAND_READ_BIT = 1,
     VK_ACCESS_INDEX_READ_BIT = 2,
@@ -735,7 +735,7 @@ enum VkAccessFlagBits  : int (int value)
     VK_ACCESS_NONE = 0,
     VK_ACCESS_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkMemoryPropertyFlagBits  : int (int value)
+enum VkMemoryPropertyFlagBits  : const int
 {
     VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT = 1,
     VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT = 2,
@@ -745,7 +745,7 @@ enum VkMemoryPropertyFlagBits  : int (int value)
     VK_MEMORY_PROPERTY_PROTECTED_BIT = 32,
     VK_MEMORY_PROPERTY_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPhysicalDeviceType  : int (int value)
+enum VkPhysicalDeviceType  : const int
 {
     VK_PHYSICAL_DEVICE_TYPE_OTHER = 0,
     VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU = 1,
@@ -754,13 +754,13 @@ enum VkPhysicalDeviceType  : int (int value)
     VK_PHYSICAL_DEVICE_TYPE_CPU = 4,
     VK_PHYSICAL_DEVICE_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPipelineBindPoint  : int (int value)
+enum VkPipelineBindPoint  : const int
 {
     VK_PIPELINE_BIND_POINT_GRAPHICS = 0,
     VK_PIPELINE_BIND_POINT_COMPUTE = 1,
     VK_PIPELINE_BIND_POINT_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPipelineCreateFlagBits  : int (int value)
+enum VkPipelineCreateFlagBits  : const int
 {
     VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT = 1,
     VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT = 2,
@@ -772,7 +772,7 @@ enum VkPipelineCreateFlagBits  : int (int value)
     VK_PIPELINE_CREATE_EARLY_RETURN_ON_FAILURE_BIT = 512,
     VK_PIPELINE_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPrimitiveTopology  : int (int value)
+enum VkPrimitiveTopology  : const int
 {
     VK_PRIMITIVE_TOPOLOGY_POINT_LIST = 0,
     VK_PRIMITIVE_TOPOLOGY_LINE_LIST = 1,
@@ -787,12 +787,12 @@ enum VkPrimitiveTopology  : int (int value)
     VK_PRIMITIVE_TOPOLOGY_PATCH_LIST = 10,
     VK_PRIMITIVE_TOPOLOGY_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkQueryControlFlagBits  : int (int value)
+enum VkQueryControlFlagBits  : const int
 {
     VK_QUERY_CONTROL_PRECISE_BIT = 1,
     VK_QUERY_CONTROL_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkQueryPipelineStatisticFlagBits  : int (int value)
+enum VkQueryPipelineStatisticFlagBits  : const int
 {
     VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT = 1,
     VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_PRIMITIVES_BIT = 2,
@@ -807,7 +807,7 @@ enum VkQueryPipelineStatisticFlagBits  : int (int value)
     VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT = 1024,
     VK_QUERY_PIPELINE_STATISTIC_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkQueryResultFlagBits  : int (int value)
+enum VkQueryResultFlagBits  : const int
 {
     VK_QUERY_RESULT_64_BIT = 1,
     VK_QUERY_RESULT_WAIT_BIT = 2,
@@ -815,14 +815,14 @@ enum VkQueryResultFlagBits  : int (int value)
     VK_QUERY_RESULT_PARTIAL_BIT = 8,
     VK_QUERY_RESULT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkQueryType  : int (int value)
+enum VkQueryType  : const int
 {
     VK_QUERY_TYPE_OCCLUSION = 0,
     VK_QUERY_TYPE_PIPELINE_STATISTICS = 1,
     VK_QUERY_TYPE_TIMESTAMP = 2,
     VK_QUERY_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkQueueFlagBits  : int (int value)
+enum VkQueueFlagBits  : const int
 {
     VK_QUEUE_GRAPHICS_BIT = 1,
     VK_QUEUE_COMPUTE_BIT = 2,
@@ -831,13 +831,13 @@ enum VkQueueFlagBits  : int (int value)
     VK_QUEUE_PROTECTED_BIT = 16,
     VK_QUEUE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSubpassContents  : int (int value)
+enum VkSubpassContents  : const int
 {
     VK_SUBPASS_CONTENTS_INLINE = 0,
     VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS = 1,
     VK_SUBPASS_CONTENTS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkResult  : int (int value)
+enum VkResult  : const int
 {
     VK_SUCCESS = 0,
     VK_NOT_READY = 1,
@@ -865,7 +865,7 @@ enum VkResult  : int (int value)
     VK_PIPELINE_COMPILE_REQUIRED = 1000297000,
     VK_RESULT_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkShaderStageFlagBits  : int (int value)
+enum VkShaderStageFlagBits  : const int
 {
     VK_SHADER_STAGE_VERTEX_BIT = 1,
     VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT = 2,
@@ -877,12 +877,12 @@ enum VkShaderStageFlagBits  : int (int value)
     VK_SHADER_STAGE_ALL = 0x7FFFFFFF,
     VK_SHADER_STAGE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSparseMemoryBindFlagBits  : int (int value)
+enum VkSparseMemoryBindFlagBits  : const int
 {
     VK_SPARSE_MEMORY_BIND_METADATA_BIT = 1,
     VK_SPARSE_MEMORY_BIND_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkStencilFaceFlagBits  : int (int value)
+enum VkStencilFaceFlagBits  : const int
 {
     VK_STENCIL_FACE_FRONT_BIT = 1,
     VK_STENCIL_FACE_BACK_BIT = 2,
@@ -890,7 +890,7 @@ enum VkStencilFaceFlagBits  : int (int value)
     VK_STENCIL_FRONT_AND_BACK = 0x00000003,
     VK_STENCIL_FACE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkStencilOp  : int (int value)
+enum VkStencilOp  : const int
 {
     VK_STENCIL_OP_KEEP = 0,
     VK_STENCIL_OP_ZERO = 1,
@@ -902,7 +902,7 @@ enum VkStencilOp  : int (int value)
     VK_STENCIL_OP_DECREMENT_AND_WRAP = 7,
     VK_STENCIL_OP_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkStructureType  : int (int value)
+enum VkStructureType  : const int
 {
     VK_STRUCTURE_TYPE_APPLICATION_INFO = 0,
     VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO = 1,
@@ -1124,7 +1124,7 @@ enum VkStructureType  : int (int value)
     VK_STRUCTURE_TYPE_DEVICE_IMAGE_MEMORY_REQUIREMENTS = 1000413003,
     VK_STRUCTURE_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSystemAllocationScope  : int (int value)
+enum VkSystemAllocationScope  : const int
 {
     VK_SYSTEM_ALLOCATION_SCOPE_COMMAND = 0,
     VK_SYSTEM_ALLOCATION_SCOPE_OBJECT = 1,
@@ -1133,12 +1133,12 @@ enum VkSystemAllocationScope  : int (int value)
     VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE = 4,
     VK_SYSTEM_ALLOCATION_SCOPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkInternalAllocationType  : int (int value)
+enum VkInternalAllocationType  : const int
 {
     VK_INTERNAL_ALLOCATION_TYPE_EXECUTABLE = 0,
     VK_INTERNAL_ALLOCATION_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSamplerAddressMode  : int (int value)
+enum VkSamplerAddressMode  : const int
 {
     VK_SAMPLER_ADDRESS_MODE_REPEAT = 0,
     VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT = 1,
@@ -1147,25 +1147,25 @@ enum VkSamplerAddressMode  : int (int value)
     VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE = 4,
     VK_SAMPLER_ADDRESS_MODE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkFilter  : int (int value)
+enum VkFilter  : const int
 {
     VK_FILTER_NEAREST = 0,
     VK_FILTER_LINEAR = 1,
     VK_FILTER_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSamplerMipmapMode  : int (int value)
+enum VkSamplerMipmapMode  : const int
 {
     VK_SAMPLER_MIPMAP_MODE_NEAREST = 0,
     VK_SAMPLER_MIPMAP_MODE_LINEAR = 1,
     VK_SAMPLER_MIPMAP_MODE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkVertexInputRate  : int (int value)
+enum VkVertexInputRate  : const int
 {
     VK_VERTEX_INPUT_RATE_VERTEX = 0,
     VK_VERTEX_INPUT_RATE_INSTANCE = 1,
     VK_VERTEX_INPUT_RATE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPipelineStageFlagBits  : int (int value)
+enum VkPipelineStageFlagBits  : const int
 {
     VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT = 1,
     VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT = 2,
@@ -1187,14 +1187,14 @@ enum VkPipelineStageFlagBits  : int (int value)
     VK_PIPELINE_STAGE_NONE = 0,
     VK_PIPELINE_STAGE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSparseImageFormatFlagBits  : int (int value)
+enum VkSparseImageFormatFlagBits  : const int
 {
     VK_SPARSE_IMAGE_FORMAT_SINGLE_MIPTAIL_BIT = 1,
     VK_SPARSE_IMAGE_FORMAT_ALIGNED_MIP_SIZE_BIT = 2,
     VK_SPARSE_IMAGE_FORMAT_NONSTANDARD_BLOCK_SIZE_BIT = 4,
     VK_SPARSE_IMAGE_FORMAT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSampleCountFlagBits  : int (int value)
+enum VkSampleCountFlagBits  : const int
 {
     VK_SAMPLE_COUNT_1_BIT = 1,
     VK_SAMPLE_COUNT_2_BIT = 2,
@@ -1205,25 +1205,25 @@ enum VkSampleCountFlagBits  : int (int value)
     VK_SAMPLE_COUNT_64_BIT = 64,
     VK_SAMPLE_COUNT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkAttachmentDescriptionFlagBits  : int (int value)
+enum VkAttachmentDescriptionFlagBits  : const int
 {
     VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT = 1,
     VK_ATTACHMENT_DESCRIPTION_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDescriptorPoolCreateFlagBits  : int (int value)
+enum VkDescriptorPoolCreateFlagBits  : const int
 {
     VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT = 1,
     VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT = 2,
     VK_DESCRIPTOR_POOL_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDependencyFlagBits  : int (int value)
+enum VkDependencyFlagBits  : const int
 {
     VK_DEPENDENCY_BY_REGION_BIT = 1,
     VK_DEPENDENCY_DEVICE_GROUP_BIT = 4,
     VK_DEPENDENCY_VIEW_LOCAL_BIT = 2,
     VK_DEPENDENCY_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkObjectType  : int (int value)
+enum VkObjectType  : const int
 {
     VK_OBJECT_TYPE_UNKNOWN = 0,
     VK_OBJECT_TYPE_INSTANCE = 1,
@@ -1256,23 +1256,23 @@ enum VkObjectType  : int (int value)
     VK_OBJECT_TYPE_PRIVATE_DATA_SLOT = 1000295000,
     VK_OBJECT_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkEventCreateFlagBits  : int (int value)
+enum VkEventCreateFlagBits  : const int
 {
     VK_EVENT_CREATE_DEVICE_ONLY_BIT = 1,
     VK_EVENT_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDescriptorUpdateTemplateType  : int (int value)
+enum VkDescriptorUpdateTemplateType  : const int
 {
     VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET = 0,
     VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPointClippingBehavior  : int (int value)
+enum VkPointClippingBehavior  : const int
 {
     VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES = 0,
     VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY = 1,
     VK_POINT_CLIPPING_BEHAVIOR_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkResolveModeFlagBits  : int (int value)
+enum VkResolveModeFlagBits  : const int
 {
     VK_RESOLVE_MODE_NONE = 0,
     VK_RESOLVE_MODE_SAMPLE_ZERO_BIT = 1,
@@ -1281,7 +1281,7 @@ enum VkResolveModeFlagBits  : int (int value)
     VK_RESOLVE_MODE_MAX_BIT = 8,
     VK_RESOLVE_MODE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDescriptorBindingFlagBits  : int (int value)
+enum VkDescriptorBindingFlagBits  : const int
 {
     VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT = 1,
     VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT = 2,
@@ -1289,13 +1289,13 @@ enum VkDescriptorBindingFlagBits  : int (int value)
     VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT = 8,
     VK_DESCRIPTOR_BINDING_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSemaphoreType  : int (int value)
+enum VkSemaphoreType  : const int
 {
     VK_SEMAPHORE_TYPE_BINARY = 0,
     VK_SEMAPHORE_TYPE_TIMELINE = 1,
     VK_SEMAPHORE_TYPE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPipelineCreationFeedbackFlagBits  : int (int value)
+enum VkPipelineCreationFeedbackFlagBits  : const int
 {
     VK_PIPELINE_CREATION_FEEDBACK_VALID_BIT = 1,
     VK_PIPELINE_CREATION_FEEDBACK_VALID_BIT_EXT = 1,
@@ -1305,12 +1305,12 @@ enum VkPipelineCreationFeedbackFlagBits  : int (int value)
     VK_PIPELINE_CREATION_FEEDBACK_BASE_PIPELINE_ACCELERATION_BIT_EXT = 4,
     VK_PIPELINE_CREATION_FEEDBACK_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSemaphoreWaitFlagBits  : int (int value)
+enum VkSemaphoreWaitFlagBits  : const int
 {
     VK_SEMAPHORE_WAIT_ANY_BIT = 1,
     VK_SEMAPHORE_WAIT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkToolPurposeFlagBits  : int (int value)
+enum VkToolPurposeFlagBits  : const int
 {
     VK_TOOL_PURPOSE_VALIDATION_BIT = 1,
     VK_TOOL_PURPOSE_VALIDATION_BIT_EXT = 1,
@@ -1478,7 +1478,7 @@ const VkFormatFeatureFlagBits2 VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_
 const VkFormatFeatureFlagBits2 VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT = 8589934592;
 const VkFormatFeatureFlagBits2 VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR = 8589934592;
 
-enum VkRenderingFlagBits  : int (int value)
+enum VkRenderingFlagBits  : const int
 {
     VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT = 1,
     VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT_KHR = 1,
@@ -1488,7 +1488,7 @@ enum VkRenderingFlagBits  : int (int value)
     VK_RENDERING_RESUMING_BIT_KHR = 4,
     VK_RENDERING_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkExternalMemoryHandleTypeFlagBits  : int (int value)
+enum VkExternalMemoryHandleTypeFlagBits  : const int
 {
     VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT = 1,
     VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT = 2,
@@ -1499,14 +1499,14 @@ enum VkExternalMemoryHandleTypeFlagBits  : int (int value)
     VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE_BIT = 64,
     VK_EXTERNAL_MEMORY_HANDLE_TYPE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkExternalMemoryFeatureFlagBits  : int (int value)
+enum VkExternalMemoryFeatureFlagBits  : const int
 {
     VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT = 1,
     VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT = 2,
     VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT = 4,
     VK_EXTERNAL_MEMORY_FEATURE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkExternalSemaphoreHandleTypeFlagBits  : int (int value)
+enum VkExternalSemaphoreHandleTypeFlagBits  : const int
 {
     VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT = 1,
     VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT = 2,
@@ -1516,18 +1516,18 @@ enum VkExternalSemaphoreHandleTypeFlagBits  : int (int value)
     VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT = 16,
     VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkExternalSemaphoreFeatureFlagBits  : int (int value)
+enum VkExternalSemaphoreFeatureFlagBits  : const int
 {
     VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT = 1,
     VK_EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE_BIT = 2,
     VK_EXTERNAL_SEMAPHORE_FEATURE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSemaphoreImportFlagBits  : int (int value)
+enum VkSemaphoreImportFlagBits  : const int
 {
     VK_SEMAPHORE_IMPORT_TEMPORARY_BIT = 1,
     VK_SEMAPHORE_IMPORT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkExternalFenceHandleTypeFlagBits  : int (int value)
+enum VkExternalFenceHandleTypeFlagBits  : const int
 {
     VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_FD_BIT = 1,
     VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_BIT = 2,
@@ -1535,18 +1535,18 @@ enum VkExternalFenceHandleTypeFlagBits  : int (int value)
     VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT = 8,
     VK_EXTERNAL_FENCE_HANDLE_TYPE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkExternalFenceFeatureFlagBits  : int (int value)
+enum VkExternalFenceFeatureFlagBits  : const int
 {
     VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT = 1,
     VK_EXTERNAL_FENCE_FEATURE_IMPORTABLE_BIT = 2,
     VK_EXTERNAL_FENCE_FEATURE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkFenceImportFlagBits  : int (int value)
+enum VkFenceImportFlagBits  : const int
 {
     VK_FENCE_IMPORT_TEMPORARY_BIT = 1,
     VK_FENCE_IMPORT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkPeerMemoryFeatureFlagBits  : int (int value)
+enum VkPeerMemoryFeatureFlagBits  : const int
 {
     VK_PEER_MEMORY_FEATURE_COPY_SRC_BIT = 1,
     VK_PEER_MEMORY_FEATURE_COPY_DST_BIT = 2,
@@ -1554,14 +1554,14 @@ enum VkPeerMemoryFeatureFlagBits  : int (int value)
     VK_PEER_MEMORY_FEATURE_GENERIC_DST_BIT = 8,
     VK_PEER_MEMORY_FEATURE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkMemoryAllocateFlagBits  : int (int value)
+enum VkMemoryAllocateFlagBits  : const int
 {
     VK_MEMORY_ALLOCATE_DEVICE_MASK_BIT = 1,
     VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT = 2,
     VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT = 4,
     VK_MEMORY_ALLOCATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSubgroupFeatureFlagBits  : int (int value)
+enum VkSubgroupFeatureFlagBits  : const int
 {
     VK_SUBGROUP_FEATURE_BASIC_BIT = 1,
     VK_SUBGROUP_FEATURE_VOTE_BIT = 2,
@@ -1573,13 +1573,13 @@ enum VkSubgroupFeatureFlagBits  : int (int value)
     VK_SUBGROUP_FEATURE_QUAD_BIT = 128,
     VK_SUBGROUP_FEATURE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkTessellationDomainOrigin  : int (int value)
+enum VkTessellationDomainOrigin  : const int
 {
     VK_TESSELLATION_DOMAIN_ORIGIN_UPPER_LEFT = 0,
     VK_TESSELLATION_DOMAIN_ORIGIN_LOWER_LEFT = 1,
     VK_TESSELLATION_DOMAIN_ORIGIN_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSamplerYcbcrModelConversion  : int (int value)
+enum VkSamplerYcbcrModelConversion  : const int
 {
     VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY = 0,
     VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_IDENTITY = 1,
@@ -1588,39 +1588,39 @@ enum VkSamplerYcbcrModelConversion  : int (int value)
     VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020 = 4,
     VK_SAMPLER_YCBCR_MODEL_CONVERSION_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSamplerYcbcrRange  : int (int value)
+enum VkSamplerYcbcrRange  : const int
 {
     VK_SAMPLER_YCBCR_RANGE_ITU_FULL = 0,
     VK_SAMPLER_YCBCR_RANGE_ITU_NARROW = 1,
     VK_SAMPLER_YCBCR_RANGE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkChromaLocation  : int (int value)
+enum VkChromaLocation  : const int
 {
     VK_CHROMA_LOCATION_COSITED_EVEN = 0,
     VK_CHROMA_LOCATION_MIDPOINT = 1,
     VK_CHROMA_LOCATION_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSamplerReductionMode  : int (int value)
+enum VkSamplerReductionMode  : const int
 {
     VK_SAMPLER_REDUCTION_MODE_WEIGHTED_AVERAGE = 0,
     VK_SAMPLER_REDUCTION_MODE_MIN = 1,
     VK_SAMPLER_REDUCTION_MODE_MAX = 2,
     VK_SAMPLER_REDUCTION_MODE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkShaderFloatControlsIndependence  : int (int value)
+enum VkShaderFloatControlsIndependence  : const int
 {
     VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY = 0,
     VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL = 1,
     VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE = 2,
     VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkSubmitFlagBits  : int (int value)
+enum VkSubmitFlagBits  : const int
 {
     VK_SUBMIT_PROTECTED_BIT = 1,
     VK_SUBMIT_PROTECTED_BIT_KHR = 1,
     VK_SUBMIT_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkVendorId  : int (int value)
+enum VkVendorId  : const int
 {
     VK_VENDOR_ID_KHRONOS = 0x10000,
     VK_VENDOR_ID_VIV = 0x10001,
@@ -1632,7 +1632,7 @@ enum VkVendorId  : int (int value)
     VK_VENDOR_ID_MOBILEYE = 0x10007,
     VK_VENDOR_ID_MAX_ENUM = 0x7FFFFFFF
 }
-enum VkDriverId  : int (int value)
+enum VkDriverId  : const int
 {
     VK_DRIVER_ID_AMD_PROPRIETARY = 1,
     VK_DRIVER_ID_AMD_OPEN_SOURCE = 2,


### PR DESCRIPTION
some of the enums are stored in structs, which would result in them being stored as their ordinal instead of their intended value. For example the structure type of `VkPhysicalDeviceSubgroupProperties` (`VkStructureType.VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_PROPERTIES`) would be stored as `49` instead of `1000094000` and would likely break when used.
Making them `const` fixes this