### PR TITLE
glfw & opengl emscripten builds

### DIFF
--- a/libraries/glfw.c3l/manifest.json
+++ b/libraries/glfw.c3l/manifest.json
@@ -1,6 +1,11 @@
 {
 	"provides": "glfw",
 	"targets" : {
+		"emscripten" : {
+			"link-args" : [],
+			"dependencies" : [],
+			"linked-libraries" : []
+		},
 		"macos-x64" : {
 			"link-args" : [],
 			"dependencies" : [],

--- a/libraries/opengl.c3l/gl.c3
+++ b/libraries/opengl.c3l/gl.c3
@@ -13734,12 +13734,21 @@ fn void load_all_gl(GLLoadFn load, int version) {
 
 fn int load_gl_internal(GLLoadFn load)
 {
-    getIntegerv = load("glGetIntegerv");
-    if (getIntegerv == null) return 0;
-    int major, minor;
-    getIntegerv((GLenum)GL_MAJOR_VERSION, &major);
-    getIntegerv((GLenum)GL_MINOR_VERSION, &minor);
-    int version = (major * 10) + minor;
-    load_all_gl(load, version);
-    return version;
+	getIntegerv = load("glGetIntegerv");
+	if (getIntegerv == null) return 0;
+	int major, minor;
+	getIntegerv((GLenum)GL_MAJOR_VERSION, &major);
+	getIntegerv((GLenum)GL_MINOR_VERSION, &minor);
+	if (major == 3 && minor == 0)
+	{
+		getString = load("glGetString");
+		String version_str = ((ZString)getString((GLenum)GL_VERSION)).str_view();
+		if (version_str.contains("WebGL 2.0"))
+		{
+			minor = 3;
+		}
+	}
+	int version = (major * 10) + minor;
+	load_all_gl(load, version);
+	return version;
 }

--- a/libraries/opengl.c3l/gl.c3
+++ b/libraries/opengl.c3l/gl.c3
@@ -13739,6 +13739,9 @@ fn int load_gl_internal(GLLoadFn load)
 	int major, minor;
 	getIntegerv((GLenum)GL_MAJOR_VERSION, &major);
 	getIntegerv((GLenum)GL_MINOR_VERSION, &minor);
+	// Treating WebGL 2.0 like OpenGL 3.3 in order to load as many of the
+	// functions defined for WebGL 2.0 as possible. Not all OpenGL 3.1 to 3.3
+	// functions are supported in WebGL 2.0, but there is overlap.
 	if (major == 3 && minor == 0)
 	{
 		getString = load("glGetString");

--- a/libraries/opengl.c3l/manifest.json
+++ b/libraries/opengl.c3l/manifest.json
@@ -1,6 +1,11 @@
 {
 	"provides" : "opengl",
 	"targets" : {
+		"emscripten" : {
+			"link-args" : [],
+			"dependencies" : [],
+			"linked-libraries" : []
+		},
 		"freebsd-x64" : {
 			"link-args" : [],
 			"dependencies" : [],


### PR DESCRIPTION
Setting opengl version to 3.3 so that we can access functions under 3.1,
3.2, and 3.3. Not all are implemented under WebGL 2.0, but some are.
Those that aren't stay as null pointers.

Specifically needed access to the uniform block functions under 3.1, but I see that WebGL 2.0 includes functions that are defined up to 3.3. Didn't see the harm in having it try to load everything up to 3.3.