### PR TITLE
[GLFW] Support macOS Silicon

### DIFF
--- a/libraries/glfw.c3l/manifest.json
+++ b/libraries/glfw.c3l/manifest.json
@@ -10,7 +10,7 @@
 			"link-args" : [ "-L /opt/homebrew/Cellar/glfw/3.4/lib" ],
 			"dependencies" : [],
 			"linked-libraries" : [ 
-			  "glfw3",
+				"glfw3",
 				"Cocoa.framework",
 				"IOKit.framework"
 			]

--- a/libraries/glfw.c3l/manifest.json
+++ b/libraries/glfw.c3l/manifest.json
@@ -7,9 +7,13 @@
 			"linked-libraries" : []
 		},
 		"macos-aarch64" : {
-			"link-args" : [],
+			"link-args" : [ "-L /opt/homebrew/Cellar/glfw/3.4/lib" ],
 			"dependencies" : [],
-			"linked-libraries" : []
+			"linked-libraries" : [ 
+			  "glfw3",
+				"Cocoa.framework",
+				"IOKit.framework"
+			]
 		},
 		"linux-x64" : {
 			"link-args" : [],


### PR DESCRIPTION
# Description

Adding support for macOS Silicon to the GLFW library.
Linking path used from brew's default install directory; supporting latest version 3.4.

# Remarks

If macOS was left out intentionally (because install path my differ), we should update the documentation or add a comment in the .c3l to inform users linking should be handled per-project instead of at the vendor level.