### PR TITLE
Add missing config flags BORDERLES_WINDOWED_MODE and WINDOW_MOUSE_PASSTHROUGH in Raylib bindings

### DIFF
--- a/libraries/raylib5.c3l/raylib.c3i
+++ b/libraries/raylib5.c3l/raylib.c3i
@@ -1923,155 +1923,161 @@ macro void @vrMode(VrStereoConfig config ;@body)
 // NOTE: Every bit registers one state (use it with bit masks)
 // By default all flags are set to 0
 
-typedef ConfigFlag @constinit = uint;
-
-const ConfigFlag FLAG_VSYNC_HINT         = 0x00000040;   // Set to try enabling V-Sync on GPU
-const ConfigFlag FLAG_FULLSCREEN_MODE    = 0x00000002;   // Set to run program in fullscreen
-const ConfigFlag FLAG_WINDOW_RESIZABLE   = 0x00000004;   // Set to allow resizable window
-const ConfigFlag FLAG_WINDOW_UNDECORATED = 0x00000008;   // Set to disable window decoration (frame and buttons)
-const ConfigFlag FLAG_WINDOW_HIDDEN      = 0x00000080;   // Set to hide window
-const ConfigFlag FLAG_WINDOW_MINIMIZED   = 0x00000200;   // Set to minimize window (iconify)
-const ConfigFlag FLAG_WINDOW_MAXIMIZED   = 0x00000400;   // Set to maximize window (expanded to monitor)
-const ConfigFlag FLAG_WINDOW_UNFOCUSED   = 0x00000800;   // Set to window non focused
-const ConfigFlag FLAG_WINDOW_TOPMOST     = 0x00001000;   // Set to window always on top
-const ConfigFlag FLAG_WINDOW_ALWAYS_RUN  = 0x00000100;   // Set to allow windows running while minimized
-const ConfigFlag FLAG_WINDOW_TRANSPARENT = 0x00000010;   // Set to allow transparent framebuffer
-const ConfigFlag FLAG_WINDOW_HIGHDPI     = 0x00002000;   // Set to support HighDPI
-const ConfigFlag FLAG_MSAA_4X_HINT       = 0x00000020;   // Set to try enabling MSAA 4X
-const ConfigFlag FLAG_INTERLACED_HINT    = 0x00010000;   // Set to try enabling interlaced video format (for V3D)
+constdef RLConfigFlag : uint
+{
+	VSYNC_HINT               = 0x00000040, // Set to try enabling V-Sync on GPU
+	FULLSCREEN_MODE          = 0x00000002, // Set to run program in fullscreen
+	WINDOW_RESIZABLE         = 0x00000004, // Set to allow resizable window
+	WINDOW_UNDECORATED       = 0x00000008, // Set to disable window decoration (frame and buttons)
+	WINDOW_HIDDEN            = 0x00000080, // Set to hide window
+	WINDOW_MINIMIZED         = 0x00000200, // Set to minimize window (iconify)
+	WINDOW_MAXIMIZED         = 0x00000400, // Set to maximize window (expanded to monitor)
+	WINDOW_UNFOCUSED         = 0x00000800, // Set to window non focused
+	WINDOW_TOPMOST           = 0x00001000, // Set to window always on top
+	WINDOW_ALWAYS_RUN        = 0x00000100, // Set to allow windows running while minimized
+	WINDOW_TRANSPARENT       = 0x00000010, // Set to allow transparent framebuffer
+	WINDOW_HIGHDPI           = 0x00002000, // Set to support HighDPI
+	WINDOW_MOUSE_PASSTHROUGH = 0x00004000, // Set to support mouse passthrough, only supported when FLAG_WINDOW_UNDECORATED
+	BORDERLESS_WINDOWED_MODE = 0x00008000, // Set to run program in borderless windowed mode
+	MSAA_4X_HINT             = 0x00000020, // Set to try enabling MSAA 4X
+	INTERLACED_HINT          = 0x00010000  // Set to try enabling interlaced video format (for V3D)
+}
 
 // Keyboard keys (US keyboard layout)
 // NOTE: Use GetKeyPressed() to allow redefining
 // required keys for alternative layouts
 
-typedef KeyboardKey @constinit = int;
+constdef KeyboardKey : int
+{
+	NULL            = 0,        // Key: NULL, used for no key pressed
+	// Alphanumeric keys
+	APOSTROPHE      = 39,       // Key: '
+	COMMA           = 44,       // Key: ,
+	MINUS           = 45,       // Key: -
+	PERIOD          = 46,       // Key: .
+	SLASH           = 47,       // Key: /
+	ZERO            = 48,       // Key: 0
+	ONE             = 49,       // Key: 1
+	TWO             = 50,       // Key: 2
+	THREE           = 51,       // Key: 3
+	FOUR            = 52,       // Key: 4
+	FIVE            = 53,       // Key: 5
+	SIX             = 54,       // Key: 6
+	SEVEN           = 55,       // Key: 7
+	EIGHT           = 56,       // Key: 8
+	NINE            = 57,       // Key: 9
+	SEMICOLON       = 59,       // Key: ,
+	EQUAL           = 61,       // Key: =
+	A               = 65,       // Key: A | a
+	B               = 66,       // Key: B | b
+	C               = 67,       // Key: C | c
+	D               = 68,       // Key: D | d
+	E               = 69,       // Key: E | e
+	F               = 70,       // Key: F | f
+	G               = 71,       // Key: G | g
+	H               = 72,       // Key: H | h
+	I               = 73,       // Key: I | i
+	J               = 74,       // Key: J | j
+	K               = 75,       // Key: K | k
+	L               = 76,       // Key: L | l
+	M               = 77,       // Key: M | m
+	N               = 78,       // Key: N | n
+	O               = 79,       // Key: O | o
+	P               = 80,       // Key: P | p
+	Q               = 81,       // Key: Q | q
+	R               = 82,       // Key: R | r
+	S               = 83,       // Key: S | s
+	T               = 84,       // Key: T | t
+	U               = 85,       // Key: U | u
+	V               = 86,       // Key: V | v
+	W               = 87,       // Key: W | w
+	X               = 88,       // Key: X | x
+	Y               = 89,       // Key: Y | y
+	Z               = 90,       // Key: Z | z
+	LEFT_BRACKET    = 91,       // Key: [
+	BACKSLASH       = 92,       // Key: '\'
+	RIGHT_BRACKET   = 93,       // Key: ]
+	GRAVE           = 96,       // Key: `
+	// Function keys
+	SPACE           = 32,       // Key: Space
+	ESCAPE          = 256,      // Key: Esc
+	ENTER           = 257,      // Key: Enter
+	TAB             = 258,      // Key: Tab
+	BACKSPACE       = 259,      // Key: Backspace
+	INSERT          = 260,      // Key: Ins
+	DELETE          = 261,      // Key: Del
+	RIGHT           = 262,      // Key: Cursor right
+	LEFT            = 263,      // Key: Cursor left
+	DOWN            = 264,      // Key: Cursor down
+	UP              = 265,      // Key: Cursor up
+	PAGE_UP         = 266,      // Key: Page up
+	PAGE_DOWN       = 267,      // Key: Page down
+	HOME            = 268,      // Key: Home
+	END             = 269,      // Key: End
+	CAPS_LOCK       = 280,      // Key: Caps lock
+	SCROLL_LOCK     = 281,      // Key: Scroll down
+	NUM_LOCK        = 282,      // Key: Num lock
+	PRINT_SCREEN    = 283,      // Key: Print screen
+	PAUSE           = 284,      // Key: Pause
+	F1              = 290,      // Key: F1
+	F2              = 291,      // Key: F2
+	F3              = 292,      // Key: F3
+	F4              = 293,      // Key: F4
+	F5              = 294,      // Key: F5
+	F6              = 295,      // Key: F6
+	F7              = 296,      // Key: F7
+	F8              = 297,      // Key: F8
+	F9              = 298,      // Key: F9
+	F10             = 299,      // Key: F10
+	F11             = 300,      // Key: F11
+	F12             = 301,      // Key: F12
+	LEFT_SHIFT      = 340,      // Key: Shift left
+	LEFT_CONTROL    = 341,      // Key: Control left
+	LEFT_ALT        = 342,      // Key: Alt left
+	LEFT_SUPER      = 343,      // Key: Super left
+	RIGHT_SHIFT     = 344,      // Key: Shift right
+	RIGHT_CONTROL   = 345,      // Key: Control right
+	RIGHT_ALT       = 346,      // Key: Alt right
+	RIGHT_SUPER     = 347,      // Key: Super right
+	KB_MENU         = 348,      // Key: KB menu
+	// Keypad keys
+	KP_0            = 320,      // Key: Keypad 0
+	KP_1            = 321,      // Key: Keypad 1
+	KP_2            = 322,      // Key: Keypad 2
+	KP_3            = 323,      // Key: Keypad 3
+	KP_4            = 324,      // Key: Keypad 4
+	KP_5            = 325,      // Key: Keypad 5
+	KP_6            = 326,      // Key: Keypad 6
+	KP_7            = 327,      // Key: Keypad 7
+	KP_8            = 328,      // Key: Keypad 8
+	KP_9            = 329,      // Key: Keypad 9
+	KP_DECIMAL      = 330,      // Key: Keypad .
+	KP_DIVIDE       = 331,      // Key: Keypad /
+	KP_MULTIPLY     = 332,      // Key: Keypad *
+	KP_SUBTRACT     = 333,      // Key: Keypad -
+	KP_ADD          = 334,      // Key: Keypad +
+	KP_ENTER        = 335,      // Key: Keypad Enter
+	KP_EQUAL        = 336,      // Key: Keypad =
+	// Android key buttons
+	BACK            = 4,        // Key: Android back button
+	MENU            = 82,       // Key: Android menu button
+	VOLUME_UP       = 24,       // Key: Android volume up button
+	VOLUME_DOWN     = 25,       // Key: Android volume down button
+}
 
-const KeyboardKey KEY_NULL            = 0;        // Key: NULL; used for no key pressed
-// Alphanumeric keys
-const KeyboardKey KEY_APOSTROPHE      = 39;       // Key: '
-const KeyboardKey KEY_COMMA           = 44;       // Key: ;
-const KeyboardKey KEY_MINUS           = 45;       // Key: -
-const KeyboardKey KEY_PERIOD          = 46;       // Key: .
-const KeyboardKey KEY_SLASH           = 47;       // Key: /
-const KeyboardKey KEY_ZERO            = 48;       // Key: 0
-const KeyboardKey KEY_ONE             = 49;       // Key: 1
-const KeyboardKey KEY_TWO             = 50;       // Key: 2
-const KeyboardKey KEY_THREE           = 51;       // Key: 3
-const KeyboardKey KEY_FOUR            = 52;       // Key: 4
-const KeyboardKey KEY_FIVE            = 53;       // Key: 5
-const KeyboardKey KEY_SIX             = 54;       // Key: 6
-const KeyboardKey KEY_SEVEN           = 55;       // Key: 7
-const KeyboardKey KEY_EIGHT           = 56;       // Key: 8
-const KeyboardKey KEY_NINE            = 57;       // Key: 9
-const KeyboardKey KEY_SEMICOLON       = 59;       // Key: ;
-const KeyboardKey KEY_EQUAL           = 61;       // Key: =
-const KeyboardKey KEY_A               = 65;       // Key: A | a
-const KeyboardKey KEY_B               = 66;       // Key: B | b
-const KeyboardKey KEY_C               = 67;       // Key: C | c
-const KeyboardKey KEY_D               = 68;       // Key: D | d
-const KeyboardKey KEY_E               = 69;       // Key: E | e
-const KeyboardKey KEY_F               = 70;       // Key: F | f
-const KeyboardKey KEY_G               = 71;       // Key: G | g
-const KeyboardKey KEY_H               = 72;       // Key: H | h
-const KeyboardKey KEY_I               = 73;       // Key: I | i
-const KeyboardKey KEY_J               = 74;       // Key: J | j
-const KeyboardKey KEY_K               = 75;       // Key: K | k
-const KeyboardKey KEY_L               = 76;       // Key: L | l
-const KeyboardKey KEY_M               = 77;       // Key: M | m
-const KeyboardKey KEY_N               = 78;       // Key: N | n
-const KeyboardKey KEY_O               = 79;       // Key: O | o
-const KeyboardKey KEY_P               = 80;       // Key: P | p
-const KeyboardKey KEY_Q               = 81;       // Key: Q | q
-const KeyboardKey KEY_R               = 82;       // Key: R | r
-const KeyboardKey KEY_S               = 83;       // Key: S | s
-const KeyboardKey KEY_T               = 84;       // Key: T | t
-const KeyboardKey KEY_U               = 85;       // Key: U | u
-const KeyboardKey KEY_V               = 86;       // Key: V | v
-const KeyboardKey KEY_W               = 87;       // Key: W | w
-const KeyboardKey KEY_X               = 88;       // Key: X | x
-const KeyboardKey KEY_Y               = 89;       // Key: Y | y
-const KeyboardKey KEY_Z               = 90;       // Key: Z | z
-const KeyboardKey KEY_LEFT_BRACKET    = 91;       // Key: [
-const KeyboardKey KEY_BACKSLASH       = 92;       // Key: '\'
-const KeyboardKey KEY_RIGHT_BRACKET   = 93;       // Key: ]
-const KeyboardKey KEY_GRAVE           = 96;       // Key: `
-// Function keys
-const KeyboardKey KEY_SPACE           = 32;       // Key: Space
-const KeyboardKey KEY_ESCAPE          = 256;      // Key: Esc
-const KeyboardKey KEY_ENTER           = 257;      // Key: Enter
-const KeyboardKey KEY_TAB             = 258;      // Key: Tab
-const KeyboardKey KEY_BACKSPACE       = 259;      // Key: Backspace
-const KeyboardKey KEY_INSERT          = 260;      // Key: Ins
-const KeyboardKey KEY_DELETE          = 261;      // Key: Del
-const KeyboardKey KEY_RIGHT           = 262;      // Key: Cursor right
-const KeyboardKey KEY_LEFT            = 263;      // Key: Cursor left
-const KeyboardKey KEY_DOWN            = 264;      // Key: Cursor down
-const KeyboardKey KEY_UP              = 265;      // Key: Cursor up
-const KeyboardKey KEY_PAGE_UP         = 266;      // Key: Page up
-const KeyboardKey KEY_PAGE_DOWN       = 267;      // Key: Page down
-const KeyboardKey KEY_HOME            = 268;      // Key: Home
-const KeyboardKey KEY_END             = 269;      // Key: End
-const KeyboardKey KEY_CAPS_LOCK       = 280;      // Key: Caps lock
-const KeyboardKey KEY_SCROLL_LOCK     = 281;      // Key: Scroll down
-const KeyboardKey KEY_NUM_LOCK        = 282;      // Key: Num lock
-const KeyboardKey KEY_PRINT_SCREEN    = 283;      // Key: Print screen
-const KeyboardKey KEY_PAUSE           = 284;      // Key: Pause
-const KeyboardKey KEY_F1              = 290;      // Key: F1
-const KeyboardKey KEY_F2              = 291;      // Key: F2
-const KeyboardKey KEY_F3              = 292;      // Key: F3
-const KeyboardKey KEY_F4              = 293;      // Key: F4
-const KeyboardKey KEY_F5              = 294;      // Key: F5
-const KeyboardKey KEY_F6              = 295;      // Key: F6
-const KeyboardKey KEY_F7              = 296;      // Key: F7
-const KeyboardKey KEY_F8              = 297;      // Key: F8
-const KeyboardKey KEY_F9              = 298;      // Key: F9
-const KeyboardKey KEY_F10             = 299;      // Key: F10
-const KeyboardKey KEY_F11             = 300;      // Key: F11
-const KeyboardKey KEY_F12             = 301;      // Key: F12
-const KeyboardKey KEY_LEFT_SHIFT      = 340;      // Key: Shift left
-const KeyboardKey KEY_LEFT_CONTROL    = 341;      // Key: Control left
-const KeyboardKey KEY_LEFT_ALT        = 342;      // Key: Alt left
-const KeyboardKey KEY_LEFT_SUPER      = 343;      // Key: Super left
-const KeyboardKey KEY_RIGHT_SHIFT     = 344;      // Key: Shift right
-const KeyboardKey KEY_RIGHT_CONTROL   = 345;      // Key: Control right
-const KeyboardKey KEY_RIGHT_ALT       = 346;      // Key: Alt right
-const KeyboardKey KEY_RIGHT_SUPER     = 347;      // Key: Super right
-const KeyboardKey KEY_KB_MENU         = 348;      // Key: KB menu
-// Keypad keys
-const KeyboardKey KEY_KP_0            = 320;      // Key: Keypad 0
-const KeyboardKey KEY_KP_1            = 321;      // Key: Keypad 1
-const KeyboardKey KEY_KP_2            = 322;      // Key: Keypad 2
-const KeyboardKey KEY_KP_3            = 323;      // Key: Keypad 3
-const KeyboardKey KEY_KP_4            = 324;      // Key: Keypad 4
-const KeyboardKey KEY_KP_5            = 325;      // Key: Keypad 5
-const KeyboardKey KEY_KP_6            = 326;      // Key: Keypad 6
-const KeyboardKey KEY_KP_7            = 327;      // Key: Keypad 7
-const KeyboardKey KEY_KP_8            = 328;      // Key: Keypad 8
-const KeyboardKey KEY_KP_9            = 329;      // Key: Keypad 9
-const KeyboardKey KEY_KP_DECIMAL      = 330;      // Key: Keypad .
-const KeyboardKey KEY_KP_DIVIDE       = 331;      // Key: Keypad /
-const KeyboardKey KEY_KP_MULTIPLY     = 332;      // Key: Keypad *
-const KeyboardKey KEY_KP_SUBTRACT     = 333;      // Key: Keypad -
-const KeyboardKey KEY_KP_ADD          = 334;      // Key: Keypad +
-const KeyboardKey KEY_KP_ENTER        = 335;      // Key: Keypad Enter
-const KeyboardKey KEY_KP_EQUAL        = 336;      // Key: Keypad =
-// Android key buttons
-const KeyboardKey KEY_BACK            = 4;        // Key: Android back button
-const KeyboardKey KEY_MENU            = 82;       // Key: Android menu button
-const KeyboardKey KEY_VOLUME_UP       = 24;       // Key: Android volume up button
-const KeyboardKey KEY_VOLUME_DOWN     = 25;       // Key: Android volume down button
-
-typedef Gesture @constinit = int;
-// Gesture
-// NOTE: It could be used as flags to enable only some gestures
-const Gesture GESTURE_NONE        = 0;      // No gesture
-const Gesture GESTURE_TAP         = 1;        // Tap gesture
-const Gesture GESTURE_DOUBLETAP   = 2;        // Double tap gesture
-const Gesture GESTURE_HOLD        = 4;        // Hold gesture
-const Gesture GESTURE_DRAG        = 8;        // Drag gesture
-const Gesture GESTURE_SWIPE_RIGHT = 16;       // Swipe right gesture
-const Gesture GESTURE_SWIPE_LEFT  = 32;       // Swipe left gesture
-const Gesture GESTURE_SWIPE_UP    = 64;       // Swipe up gesture
-const Gesture GESTURE_SWIPE_DOWN  = 128;      // Swipe down gesture
-const Gesture GESTURE_PINCH_IN    = 256;      // Pinch in gesture
-const Gesture GESTURE_PINCH_OUT   = 512;      // Pinch out gesture
+constdef Gesture : int
+{
+	// Gesture
+	// NOTE: It could be used as flags to enable only some gestures
+	NONE        = 0,      // No gesture
+	TAP         = 1,        // Tap gesture
+	DOUBLETAP   = 2,        // Double tap gesture
+	HOLD        = 4,        // Hold gesture
+	DRAG        = 8,        // Drag gesture
+	SWIPE_RIGHT = 16,       // Swipe right gesture
+	SWIPE_LEFT  = 32,       // Swipe left gesture
+	SWIPE_UP    = 64,       // Swipe up gesture
+	SWIPE_DOWN  = 128,      // Swipe down gesture
+	PINCH_IN    = 256,      // Pinch in gesture
+	PINCH_OUT   = 512,      // Pinch out gesture
+}

--- a/libraries/raylib5.c3l/raylib.c3i
+++ b/libraries/raylib5.c3l/raylib.c3i
@@ -1923,7 +1923,7 @@ macro void @vrMode(VrStereoConfig config ;@body)
 // NOTE: Every bit registers one state (use it with bit masks)
 // By default all flags are set to 0
 
-constdef RLConfigFlag : uint
+constdef ConfigFlag : uint
 {
 	VSYNC_HINT               = 0x00000040, // Set to try enabling V-Sync on GPU
 	FULLSCREEN_MODE          = 0x00000002, // Set to run program in fullscreen

--- a/libraries/raylib55.c3l/raylib.c3i
+++ b/libraries/raylib55.c3l/raylib.c3i
@@ -1497,20 +1497,22 @@ macro void @rl_mode(CInt mode ;@body)
 // By default all flags are set to 0
 constdef RLConfigFlag : uint
 {
-	VSYNC_HINT         = 0x00000040, // Set to try enabling V-Sync on GPU
-	FULLSCREEN_MODE    = 0x00000002, // Set to run program in fullscreen
-	WINDOW_RESIZABLE   = 0x00000004, // Set to allow resizable window
-	WINDOW_UNDECORATED = 0x00000008, // Set to disable window decoration (frame and buttons)
-	WINDOW_HIDDEN      = 0x00000080, // Set to hide window
-	WINDOW_MINIMIZED   = 0x00000200, // Set to minimize window (iconify)
-	WINDOW_MAXIMIZED   = 0x00000400, // Set to maximize window (expanded to monitor)
-	WINDOW_UNFOCUSED   = 0x00000800, // Set to window non focused
-	WINDOW_TOPMOST     = 0x00001000, // Set to window always on top
-	WINDOW_ALWAYS_RUN  = 0x00000100, // Set to allow windows running while minimized
-	WINDOW_TRANSPARENT = 0x00000010, // Set to allow transparent framebuffer
-	WINDOW_HIGHDPI     = 0x00002000, // Set to support HighDPI
-	MSAA_4X_HINT       = 0x00000020, // Set to try enabling MSAA 4X
-	INTERLACED_HINT    = 0x00010000  // Set to try enabling interlaced video format (for V3D)
+	VSYNC_HINT               = 0x00000040, // Set to try enabling V-Sync on GPU
+	FULLSCREEN_MODE          = 0x00000002, // Set to run program in fullscreen
+	WINDOW_RESIZABLE         = 0x00000004, // Set to allow resizable window
+	WINDOW_UNDECORATED       = 0x00000008, // Set to disable window decoration (frame and buttons)
+	WINDOW_HIDDEN            = 0x00000080, // Set to hide window
+	WINDOW_MINIMIZED         = 0x00000200, // Set to minimize window (iconify)
+	WINDOW_MAXIMIZED         = 0x00000400, // Set to maximize window (expanded to monitor)
+	WINDOW_UNFOCUSED         = 0x00000800, // Set to window non focused
+	WINDOW_TOPMOST           = 0x00001000, // Set to window always on top
+	WINDOW_ALWAYS_RUN        = 0x00000100, // Set to allow windows running while minimized
+	WINDOW_TRANSPARENT       = 0x00000010, // Set to allow transparent framebuffer
+	WINDOW_HIGHDPI           = 0x00002000, // Set to support HighDPI
+	WINDOW_MOUSE_PASSTHROUGH = 0x00004000, // Set to support mouse passthrough, only supported when FLAG_WINDOW_UNDECORATED
+	BORDERLESS_WINDOWED_MODE = 0x00008000, // Set to run program in borderless windowed mode
+	MSAA_4X_HINT             = 0x00000020, // Set to try enabling MSAA 4X
+	INTERLACED_HINT          = 0x00010000  // Set to try enabling interlaced video format (for V3D)
 }
 
 // Keyboard keys (US keyboard layout)

--- a/libraries/raylib6.c3l/raylib.c3i
+++ b/libraries/raylib6.c3l/raylib.c3i
@@ -1511,20 +1511,22 @@ macro void @gl_mode(int mode ;@body)
 // By default all flags are set to 0
 constdef RLConfigFlag : uint
 {
-	VSYNC_HINT         = 0x00000040, // Set to try enabling V-Sync on GPU
-	FULLSCREEN_MODE    = 0x00000002, // Set to run program in fullscreen
-	WINDOW_RESIZABLE   = 0x00000004, // Set to allow resizable window
-	WINDOW_UNDECORATED = 0x00000008, // Set to disable window decoration (frame and buttons)
-	WINDOW_HIDDEN      = 0x00000080, // Set to hide window
-	WINDOW_MINIMIZED   = 0x00000200, // Set to minimize window (iconify)
-	WINDOW_MAXIMIZED   = 0x00000400, // Set to maximize window (expanded to monitor)
-	WINDOW_UNFOCUSED   = 0x00000800, // Set to window non focused
-	WINDOW_TOPMOST     = 0x00001000, // Set to window always on top
-	WINDOW_ALWAYS_RUN  = 0x00000100, // Set to allow windows running while minimized
-	WINDOW_TRANSPARENT = 0x00000010, // Set to allow transparent framebuffer
-	WINDOW_HIGHDPI     = 0x00002000, // Set to support HighDPI
-	MSAA_4X_HINT       = 0x00000020, // Set to try enabling MSAA 4X
-	INTERLACED_HINT    = 0x00010000  // Set to try enabling interlaced video format (for V3D)
+	VSYNC_HINT               = 0x00000040, // Set to try enabling V-Sync on GPU
+	FULLSCREEN_MODE          = 0x00000002, // Set to run program in fullscreen
+	WINDOW_RESIZABLE         = 0x00000004, // Set to allow resizable window
+	WINDOW_UNDECORATED       = 0x00000008, // Set to disable window decoration (frame and buttons)
+	WINDOW_HIDDEN            = 0x00000080, // Set to hide window
+	WINDOW_MINIMIZED         = 0x00000200, // Set to minimize window (iconify)
+	WINDOW_MAXIMIZED         = 0x00000400, // Set to maximize window (expanded to monitor)
+	WINDOW_UNFOCUSED         = 0x00000800, // Set to window non focused
+	WINDOW_TOPMOST           = 0x00001000, // Set to window always on top
+	WINDOW_ALWAYS_RUN        = 0x00000100, // Set to allow windows running while minimized
+	WINDOW_TRANSPARENT       = 0x00000010, // Set to allow transparent framebuffer
+	WINDOW_HIGHDPI           = 0x00002000, // Set to support HighDPI
+	WINDOW_MOUSE_PASSTHROUGH = 0x00004000, // Set to support mouse passthrough, only supported when FLAG_WINDOW_UNDECORATED
+	BORDERLESS_WINDOWED_MODE = 0x00008000, // Set to run program in borderless windowed mode
+	MSAA_4X_HINT             = 0x00000020, // Set to try enabling MSAA 4X
+	INTERLACED_HINT          = 0x00010000  // Set to try enabling interlaced video format (for V3D)
 }
 
 // Keyboard keys (US keyboard layout)


### PR DESCRIPTION
closes: #138 
- converted the typedefs ConfigFlag, KeyboardKey and Gesture to constdefs in raylib5
- added the missing flags BORDERLES_WINDOWED_MODE and WINDOW_MOUSE_PASSTHROUGH to the config flags constdefs of all 3 raylib version bindings