### PR TITLE
remove dependency on Xxf86vm for raylib6

### DIFF
--- a/libraries/raylib6.c3l/manifest.json
+++ b/libraries/raylib6.c3l/manifest.json
@@ -37,7 +37,6 @@
 		"Xrandr",
 		"Xinerama",
 		"Xi",
-		"Xxf86vm",
 		"Xcursor",
 		"m"
 	  ]
@@ -52,7 +51,6 @@
 		"Xrandr",
 		"Xinerama",
 		"Xi",
-		"Xxf86vm",
 		"Xcursor",
 		"m"
 	  ]


### PR DESCRIPTION
raylib doesn't require xxf86vm to function, not mentioned by the wiki page of raylib, nor Arch Linux raylib package:
<img width="185" height="214" alt="image" src="https://github.com/user-attachments/assets/9a5972c6-0f63-4a17-974c-e6e065bba41b" />


https://github.com/raysan5/raylib/wiki/Working-on-GNU-Linux
