### PR TITLE
add windows-aarch64 support to few vendor libs

### DIFF
--- a/.github/actions/build-static-lib/action.yml
+++ b/.github/actions/build-static-lib/action.yml
@@ -13,8 +13,10 @@ inputs:
   linux_lib: { required: false }
   mac_url: { required: false }
   mac_lib: { required: false }
-  win_url: { required: false }
-  win_lib: { required: false }
+  win_arm64_url: { required: false }
+  win_arm64_lib: { required: false }
+  win_amd64_url: { required: false }
+  win_amd64_lib: { required: false }
   os: { required: true }
   # Post-Processing Options
   after_build: { required: false, default: "" }
@@ -39,7 +41,11 @@ runs:
       run: |
         set -x
         if [ "${{ runner.os }}" == "Windows" ]; then
-          TARGET_DIR="windows-x64"
+          if [[ "${{ inputs.os }}" == "windows-11-arm" ]]; then
+            TARGET_DIR="windows-aarch64"
+          else
+            TARGET_DIR="windows-x64"
+          fi
         elif [[ "${{ inputs.os }}" == "macos-latest" ]]; then
           TARGET_DIR="macos-aarch64"
         else
@@ -53,8 +59,13 @@ runs:
         BIN_URL=""
         BIN_LIB=""
         if [ "${{ runner.os }}" == "Windows" ]; then
-          BIN_URL="${{ inputs.win_url }}"
-          BIN_LIB="${{ inputs.win_lib }}"
+          if [[ "${{ inputs.os }}" == "windows-11-arm" ]]; then
+            BIN_URL="${{ inputs.win_arm64_url }}"
+            BIN_LIB="${{ inputs.win_arm64_lib }}"
+          else
+            BIN_URL="${{ inputs.win_amd64_url }}"
+            BIN_LIB="${{ inputs.win_amd64_lib }}"
+          fi
         elif [[ "${{ inputs.os }}" == "macos-latest" ]]; then
           BIN_URL="${{ inputs.mac_url }}"
           BIN_LIB="${{ inputs.mac_lib }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
   build-box2d:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -59,7 +59,7 @@ jobs:
   build-sdl3:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -88,7 +88,7 @@ jobs:
     needs: [build-sdl3]
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -116,7 +116,7 @@ jobs:
     needs: [build-sdl3]
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -143,7 +143,7 @@ jobs:
   build-lz4:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -161,7 +161,7 @@ jobs:
   build-tree_sitter:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -192,8 +192,8 @@ jobs:
           cmake_flags: "-DGLFW_BUILD_EXAMPLES=OFF -DGLFW_BUILD_TESTS=OFF -DGLFW_BUILD_DOCS=OFF"
           mac_url: "https://github.com/glfw/glfw/releases/download/3.4/glfw-3.4.bin.MACOS.zip"
           mac_lib: "glfw-3.4.bin.MACOS/lib-universal/libglfw3.a"
-          win_url: "https://github.com/glfw/glfw/releases/download/3.4/glfw-3.4.bin.WIN64.zip"
-          win_lib: "glfw-3.4.bin.WIN64/lib-vc2022/glfw3.lib"
+          win_amd64_url: "https://github.com/glfw/glfw/releases/download/3.4/glfw-3.4.bin.WIN64.zip"
+          win_amd64_lib: "glfw-3.4.bin.WIN64/lib-vc2022/glfw3.lib"
           os: ${{ matrix.os }}
           after_build: |
              # Normalize libglfw3 -> libglfw for C3
@@ -207,7 +207,7 @@ jobs:
   build-ktx:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -224,7 +224,7 @@ jobs:
   build-raylib6:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -232,7 +232,7 @@ jobs:
         if: runner.os == 'Windows'
         uses: TheMrMilchmann/setup-msvc-dev@v4
         with:
-          arch: x64
+          arch: ${{ matrix.os == 'windows-11-arm' && 'arm64' || 'x64' }}
 
       - name: Setup emsdk
         if: runner.os == 'Linux'
@@ -250,13 +250,19 @@ jobs:
           linux_lib: "raylib-6.0_linux_amd64/lib/libraylib.a"
           mac_url: "https://github.com/raysan5/raylib/releases/download/6.0/raylib-6.0_macos.tar.gz"
           mac_lib: "raylib-6.0_macos/lib/libraylib.a"
-          win_url: "https://github.com/raysan5/raylib/releases/download/6.0/raylib-6.0_win64_msvc16.zip"
-          win_lib: "raylib-6.0_win64_msvc16/lib/raylib.lib"
+          win_amd64_url: "https://github.com/raysan5/raylib/releases/download/6.0/raylib-6.0_win64_msvc16.zip"
+          win_amd64_lib: "raylib-6.0_win64_msvc16/lib/raylib.lib"
+          win_arm64_url: "https://github.com/raysan5/raylib/releases/download/6.0/raylib-6.0_winarm64_msvc16.zip"
+          win_arm64_lib: "raylib-6.0_winarm64_msvc16/lib/raylib.lib"
           os: ${{ matrix.os }}
           after_build: |
             set -x
             if [ "${{ runner.os }}" == "Windows" ]; then
-              TARGET_DIR="windows-x64"
+              if [[ "${{ matrix.os }}" == "windows-11-arm" ]]; then
+                TARGET_DIR="windows-aarch64"
+              else
+                TARGET_DIR="windows-x64"
+              fi
               LIB_NAME="raygui.lib"
             elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
               TARGET_DIR="macos-aarch64"
@@ -329,8 +335,8 @@ jobs:
           linux_lib: "raylib-5.5_linux_amd64/lib/libraylib.a"
           mac_url: "https://github.com/raysan5/raylib/releases/download/5.5/raylib-5.5_macos.tar.gz"
           mac_lib: "raylib-5.5_macos/lib/libraylib.a"
-          win_url: "https://github.com/raysan5/raylib/releases/download/5.5/raylib-5.5_win64_msvc16.zip"
-          win_lib: "raylib-5.5_win64_msvc16/lib/raylib.lib"
+          win_amd64_url: "https://github.com/raysan5/raylib/releases/download/5.5/raylib-5.5_win64_msvc16.zip"
+          win_amd64_lib: "raylib-5.5_win64_msvc16/lib/raylib.lib"
           os: ${{ matrix.os }}
 
   build-raylib5:
@@ -350,8 +356,8 @@ jobs:
           linux_lib: "raylib-5.0_linux_amd64/lib/libraylib.a"
           mac_url: "https://github.com/raysan5/raylib/releases/download/5.0/raylib-5.0_macos.tar.gz"
           mac_lib: "raylib-5.0_macos/lib/libraylib.a"
-          win_url: "https://github.com/raysan5/raylib/releases/download/5.0/raylib-5.0_win64_msvc16.zip"
-          win_lib: "raylib-5.0_win64_msvc16/lib/raylib.lib"
+          win_amd64_url: "https://github.com/raysan5/raylib/releases/download/5.0/raylib-5.0_win64_msvc16.zip"
+          win_amd64_lib: "raylib-5.0_win64_msvc16/lib/raylib.lib"
           os: ${{ matrix.os }}
 
   build-webgpu:
@@ -371,8 +377,8 @@ jobs:
           linux_lib: "libwgpu_native.a"
           mac_url: "https://github.com/gfx-rs/wgpu-native/releases/download/v0.19.1.1/wgpu-macos-aarch64-release.zip"
           mac_lib: "libwgpu_native.a"
-          win_url: "https://github.com/gfx-rs/wgpu-native/releases/download/v0.19.1.1/wgpu-windows-x86_64-release.zip"
-          win_lib: "wgpu_native.lib"
+          win_amd64_url: "https://github.com/gfx-rs/wgpu-native/releases/download/v0.19.1.1/wgpu-windows-x86_64-release.zip"
+          win_amd64_lib: "wgpu_native.lib"
           os: ${{ matrix.os }}
 
   build-tigr:

--- a/libraries/box2d.c3l/manifest.json
+++ b/libraries/box2d.c3l/manifest.json
@@ -16,8 +16,11 @@
 			"dependencies" : [],
 			"linked-libraries" : ["box2d"]
 		},
-	"windows-x64" : {
-		"linked-libraries" : ["box2d"]
-	}
+		"windows-x64" : {
+			"linked-libraries" : ["box2d"]
+		},
+		"windows-aarch64" : {
+			"linked-libraries" : ["box2d"]
+		}
 	}
 }

--- a/libraries/ktx.c3l/manifest.json
+++ b/libraries/ktx.c3l/manifest.json
@@ -80,6 +80,6 @@
 			"link-args" : [],
 			"dependencies" : [],
 			"linked-libraries" : [ "ktx", "astcenc-avx2-static", "fmt", "imageio", "ktx_read", "obj_basisu_cbind", "objUtil" ]
-		},
+		}
 	}
 }

--- a/libraries/lz4.c3l/manifest.json
+++ b/libraries/lz4.c3l/manifest.json
@@ -18,6 +18,9 @@
 		},
 		"windows-x64" : {
 			"linked-libraries" : ["lz4"]
+		},
+		"windows-aarch64" : {
+			"linked-libraries" : ["lz4"]
 		}
 	}
 }

--- a/libraries/raylib6.c3l/manifest.json
+++ b/libraries/raylib6.c3l/manifest.json
@@ -73,6 +73,15 @@
 	  ],
 	  "wincrt": "none"
 	},
+	"windows-aarch64": {
+	  "linked-libraries": [
+		"raylib",
+		"raygui",
+		"gdi32",
+		"winmm"
+	  ],
+	  "wincrt": "none"
+	},
 	"wasm32": {
 	  "linked-libraries": [
 		"raylib",

--- a/libraries/sdl3.c3l/manifest.json
+++ b/libraries/sdl3.c3l/manifest.json
@@ -80,6 +80,6 @@
 			"link-args" : [],
 			"dependencies" : [],
 			"linked-libraries" : [ "SDL3", "user32", "gdi32", "winmm", "imm32", "ole32", "oleaut32", "version", "uuid", "advapi32", "setupapi", "shell32" ]
-		},
+		}
 	}
 }

--- a/libraries/sdl3_image.c3l/manifest.json
+++ b/libraries/sdl3_image.c3l/manifest.json
@@ -80,6 +80,6 @@
 			"link-args" : [],
 			"dependencies" : [],
 			"linked-libraries" : [ "SDL3", "SDL3_image", "libpng16-16", "libsharpyuv", "libwebp", "libwebpmux", "tiff", "webpdecode", "webpdsp", "webpencode", "webputils", "zlibstatic", "user32", "gdi32", "winmm", "imm32", "ole32", "oleaut32", "version", "uuid", "advapi32", "setupapi", "shell32" ]
-		},
+		}
 	}
 }

--- a/libraries/sdl3_ttf.c3l/manifest.json
+++ b/libraries/sdl3_ttf.c3l/manifest.json
@@ -80,6 +80,6 @@
 			"link-args" : [],
 			"dependencies" : [],
 			"linked-libraries" : [ "SDL3", "SDL3_ttf", "freetype", "harfbuzz", "plutosvg", "plutovg", "usp10", "rpcrt4" ]
-		},
+		}
 	}
 }

--- a/libraries/tree_sitter.c3l/manifest.json
+++ b/libraries/tree_sitter.c3l/manifest.json
@@ -31,5 +31,8 @@
 		"windows-x64" : {
 			"linked-libraries" : ["tree-sitter"]
 		},
-	},
+		"windows-aarch64" : {
+			"linked-libraries" : ["tree-sitter"]
+		}
+	}
 }


### PR DESCRIPTION
The following changes were made:

- `build-static-lib/action.yml` now allows building static libs for `windows-aarch64` target.

- Only few vendor bindings have support for `windows-aarch64` on the given version in the workflow:
    - `box2d`
    - `sdl3`
    - `sdl3-image`
    - `sdl3-ttf`
    - `lz4`
    - `tree-sitter`
    - `ktx`
    - `raylib6`

- The `manifest.json` of the above vendor bindings have been updated where windows-aarch64 target was not added in few of them.