### PR TITLE
[raylib6] Add missing rlgl bindings and update shader bindings

### DIFF
--- a/libraries/raylib6.c3l/raylib.c3i
+++ b/libraries/raylib6.c3l/raylib.c3i
@@ -1797,9 +1797,11 @@ fn void gl_set_cull_face(int mode) @cname("rlSetCullFace"); // Set face culling 
 fn void gl_enable_scissor_test() @cname("rlEnableScissorTest");                 // Enable scissor test
 fn void gl_disable_scissor_test() @cname("rlDisableScissorTest");              // Disable scissor test
 fn void gl_scissor(int x, int y, int width, int height) @cname("rlScissor"); // Scissor test
-fn void gl_enable_wire_mode() @cname("rlEnableWireMode");               // Enable wire mode
 fn void gl_enable_point_mode() @cname("rlEnablePointMode");        // Enable point mode
-fn void gl_disable_point_mode() @cname("rlDisablePointMode");                  // Disable point mode
+fn void gl_disable_point_mode() @cname("rlDisablePointMode");      // Disable point mode
+fn void gl_set_point_size(float size) @cname("rlSetPointSize");    // Set the point drawing size
+fn float gl_get_point_size() @cname("rlGetPointSize");             // Get the point drawing size
+fn void gl_enable_wire_mode() @cname("rlEnableWireMode");               // Enable wire mode
 fn void gl_disable_wire_mode() @cname("rlDisableWireMode");              // Disable wire mode
 fn void gl_set_line_width(float width) @cname("rlSetLineWidth");    // Set the line drawing width
 fn float gl_get_line_width() @cname("rlGetLineWidth");             // Get the line drawing width

--- a/libraries/raylib6.c3l/raylib.c3i
+++ b/libraries/raylib6.c3l/raylib.c3i
@@ -1878,6 +1878,9 @@ fn uint gl_load_framebuffer() @cname("rlLoadFramebuffer");                      
 fn void gl_framebuffer_attach(uint fbo_id, uint tex_id, int attach_type, int tex_type, int mip_level) @cname("rlFramebufferAttach"); // Attach texture/renderbuffer to a framebuffer
 fn bool gl_framebuffer_complete(uint id) @cname("rlFramebufferComplete");                        // Verify framebuffer is complete
 fn void gl_unload_framebuffer(uint id) @cname("rlUnloadFramebuffer");                          // Delete framebuffer from GPU
+// WARNING: Copy and resize framebuffer functionality only defined for software backend
+fn void gl_copy_framebuffer(int x, int y, int width, int height, int format, void *pixels) @cname("rlCopyFramebuffer"); // Copy framebuffer pixel data to internal buffer
+fn void gl_resize_framebuffer(int width, int height) @cname("rlResizeFramebuffer");                    // Resize internal framebuffer
 
 // Shaders management
 fn uint gl_load_shader_code(char* vs_code, char* fs_code) @cname("rlLoadShaderCode");    // Load shader from code strings

--- a/libraries/raylib6.c3l/raylib.c3i
+++ b/libraries/raylib6.c3l/raylib.c3i
@@ -1840,6 +1840,9 @@ fn int* gl_get_shader_locs_default() @cname("rlGetShaderLocsDefault"); // Get de
 // Render batch management
 // NOTE: rlgl provides a default render batch to behave like OpenGL 1.1 immediate mode
 // but this render batch API is exposed in case of custom batches are required
+fn void gl_draw_render_batch_active() @cname("rlDrawRenderBatchActive");               // Update and draw internal render batch
+fn bool gl_check_render_batch_limit(int v_count) @cname("rlCheckRenderBatchLimit");         // Check internal buffer overflow for a given number of vertex
+
 fn void gl_set_texture(uint id) @cname("rlSetTexture"); // Set current texture for render batch and check buffers limits
 
 // Vertex buffers management

--- a/libraries/raylib6.c3l/raylib.c3i
+++ b/libraries/raylib6.c3l/raylib.c3i
@@ -1826,6 +1826,7 @@ fn void gl_set_blend_factors_separate(int gl_src_rgb, int gl_dst_rgb, int gl_src
 fn void gl_init(int width, int height) @cname("rlglInit");         // Initialize rlgl (buffers, shaders, textures, states)
 fn void gl_close() @cname("rlglClose");                       // De-initialize rlgl (buffers, shaders, textures)
 fn void gl_load_extensions(void* loader) @cname("rlLoadExtensions");                    // Load OpenGL extensions (loader function required)
+fn void* gl_get_proc_address(char* proc_name) @cname("rlGetProcAddress");   // Get OpenGL procedure address
 fn int gl_get_version() @cname("rlGetVersion");                            // Get current OpenGL version
 fn void gl_set_framebuffer_width(int width) @cname("rlSetFramebufferWidth");        // Set current framebuffer width
 fn int gl_get_framebuffer_width() @cname("rlGetFramebufferWidth");                      // Get default framebuffer width

--- a/libraries/raylib6.c3l/raylib.c3i
+++ b/libraries/raylib6.c3l/raylib.c3i
@@ -1883,9 +1883,11 @@ fn void gl_copy_framebuffer(int x, int y, int width, int height, int format, voi
 fn void gl_resize_framebuffer(int width, int height) @cname("rlResizeFramebuffer");                    // Resize internal framebuffer
 
 // Shaders management
-fn uint gl_load_shader_code(char* vs_code, char* fs_code) @cname("rlLoadShaderCode");    // Load shader from code strings
-fn uint gl_compile_shader(char* shader_code, int type) @cname("rlCompileShader");           // Compile custom shader and return shader id (type: RL_VERTEX_SHADER, RL_FRAGMENT_SHADER, RL_COMPUTE_SHADER)
-fn uint gl_load_shader_program(uint vshader_id, uint fshader_id) @cname("rlLoadShaderProgram"); // Load custom shader program
+fn uint gl_load_shader(char* code, int type) @cname("rlLoadShader");                    // Load (compile) shader and return shader id (type: RL_VERTEX_SHADER, RL_FRAGMENT_SHADER, RL_COMPUTE_SHADER)
+fn uint gl_load_shader_program(char* vs_code, char* fs_code) @cname("rlLoadShaderProgram"); // Load shader from code strings
+fn uint gl_load_shader_program_ex(uint vs_id, uint fs_id) @cname("rlLoadShaderProgramEx"); // Load shader program, using already loaded shader ids
+fn uint gl_load_shader_program_compute(uint cs_id) @cname("rlLoadShaderProgramCompute");               // Load compute shader program
+fn void gl_unload_shader(uint id) @cname("rlUnloadShader");                                     // Unload shader, loaded with rlLoadShader()
 fn void gl_unload_shader_program(uint id) @cname("rlUnloadShaderProgram");                              // Unload shader program
 fn int gl_get_location_uniform(uint shader_id, char* uniform_name) @cname("rlGetLocationUniform"); // Get shader location uniform
 fn int gl_get_location_attrib(uint shader_id, char* attrib_name) @cname("rlGetLocationAttrib");   // Get shader location attribute
@@ -1896,7 +1898,6 @@ fn void gl_set_uniform_sampler(int loc_index, uint texture_id) @cname("rlSetUnif
 fn void gl_set_shader(uint id, int* locs) @cname("rlSetShader");                             // Set shader currently active (id and locations)
 
 // Compute shader management
-fn uint gl_load_compute_shader_program(uint shader_id) @cname("rlLoadComputeShaderProgram");           // Load compute shader program
 fn void gl_compute_shader_dispatch(uint group_x, uint group_y, uint group_z) @cname("rlComputeShaderDispatch"); // Dispatch compute shader (equivalent to *draw* for graphics pipeline)
 
 // Shader buffer storage object management (ssbo)

--- a/libraries/raylib6.c3l/raylib.c3i
+++ b/libraries/raylib6.c3l/raylib.c3i
@@ -1825,7 +1825,7 @@ fn void gl_set_blend_factors_separate(int gl_src_rgb, int gl_dst_rgb, int gl_src
 // rlgl initialization functions
 fn void gl_init(int width, int height) @cname("rlglInit");         // Initialize rlgl (buffers, shaders, textures, states)
 fn void gl_close() @cname("rlglClose");                       // De-initialize rlgl (buffers, shaders, textures)
-fn void gl_load_extensions(void* loader) @cname("rlglInit");                    // Load OpenGL extensions (loader function required)
+fn void gl_load_extensions(void* loader) @cname("rlLoadExtensions");                    // Load OpenGL extensions (loader function required)
 fn int gl_get_version() @cname("rlGetVersion");                            // Get current OpenGL version
 fn void gl_set_framebuffer_width(int width) @cname("rlSetFramebufferWidth");        // Set current framebuffer width
 fn int gl_get_framebuffer_width() @cname("rlGetFramebufferWidth");                      // Get default framebuffer width

--- a/libraries/raylib6.c3l/raylib.c3i
+++ b/libraries/raylib6.c3l/raylib.c3i
@@ -151,12 +151,12 @@ struct RLMesh
     // Skin data for animation
     int bone_count;          // Number of bones (MAX: 256 bones)
     char* bone_indices;      // Vertex bone indices, up to 4 bones influence by vertex (skinning) (shader-location = 6)
-    float *bone_weights;     // Vertex bone weight, up to 4 bones influence by vertex (skinning) (shader-location = 7)
+    float* bone_weights;     // Vertex bone weight, up to 4 bones influence by vertex (skinning) (shader-location = 7)
 
     // Runtime animation vertex data (CPU skinning)
     // NOTE: In case of GPU skinning, not used, pointers are NULL
-    float *anim_vertices;    // Animated vertex positions (after bones transformations)
-    float *anim_normals;     // Animated normals (after bones transformations)
+    float* anim_vertices;    // Animated vertex positions (after bones transformations)
+    float* anim_normals;     // Animated normals (after bones transformations)
 
 	// OpenGL identifiers
 	uint vao_id;  // OpenGL Vertex Array Object id
@@ -237,7 +237,7 @@ struct RLModelAnimation
 
     int bone_count;                  // Number of bones (per pose)
     int keyframe_count;              // Number of animation key frames
-    RLModelAnimPose *keyframe_poses; // Animation sequence keyframe poses [keyframe][pose]
+    RLModelAnimPose* keyframe_poses; // Animation sequence keyframe poses [keyframe][pose]
 }
 
 // RLRay, ray for raycasting
@@ -1147,8 +1147,8 @@ fn RLFont load_font_ex(ZString file_name, int font_size, int* codepoints, int co
 fn RLFont load_font_from_image(RLImage image, RLColor key, int firstChar) @cname("LoadFontFromImage");                 // Load font from RLImage (XNA style)
 fn RLFont load_font_from_memory(ZString file_type, char* file_data, int data_size, int font_size, int* codepoints, int codepoint_count) @cname("LoadFontFromMemory"); // Load font from memory buffer, file_type refers to extension: i.e. '.ttf'
 fn bool RLFont.is_valid(RLFont font) @cname("IsFontValid"); // Check if a font is valid (font data loaded, WARNING: GPU texture not checked)
-fn RLGlyphInfo* load_font_data(char* file_data, int data_size, int font_size, int* codepoints, int codepoint_count, RLFontType type, int *glyph_count) @cname("LoadFontData");             // Load font data for further use
-fn RLImage gen_image_font_atlas(RLGlyphInfo* glyphs, Rect* *glyphRecs, int glyph_count, int font_size, int padding, int pack_method) @cname("GenImageFontAtlas"); // Generate image font atlas using chars info
+fn RLGlyphInfo* load_font_data(char* file_data, int data_size, int font_size, int* codepoints, int codepoint_count, RLFontType type, int* glyph_count) @cname("LoadFontData");             // Load font data for further use
+fn RLImage gen_image_font_atlas(RLGlyphInfo* glyphs, Rect** glyphRecs, int glyph_count, int font_size, int padding, int pack_method) @cname("GenImageFontAtlas"); // Generate image font atlas using chars info
 fn void unload_font_data(RLGlyphInfo* glyphs, int glyph_count) @cname("UnloadFontData"); // Unload font chars info data (RAM)
 fn void unload_font(RLFont font) @cname("UnloadFont");                                    // Unload font from GPU memory (VRAM)
 fn bool export_font_as_code(RLFont font, ZString file_name) @cname("ExportFontAsCode");   // Export font as code file, returns true on success
@@ -1186,7 +1186,7 @@ fn ZString codepoint_to_utf8(int codepoint, int* utf8_size) @cname("CodepointToU
 // WARNING 1: Most of these functions use internal static buffers[], it's recommended to store returned data on user-side for re-use
 // WARNING 2: Some strings allocate memory internally for the returned strings, those strings must be free by user using MemFree()
 fn ZString* load_text_lines(ZString text, int* count) @cname("LoadTextLines");                     // Load text as separate lines ('\n')
-fn void unload_text_lines(ZString *text, int line_count) @cname("UnloadTextLines");                // Unload text lines
+fn void unload_text_lines(ZString* text, int line_count) @cname("UnloadTextLines");                // Unload text lines
 fn int text_copy(ZString dst, ZString src) @cname("TextCopy");                                     // Copy one string to another, returns bytes copied
 fn bool text_is_equal(ZString text1, ZString text2) @cname("TextIsEqual");                         // Check if two text string are equal
 fn uint text_length(ZString text) @cname("TextLength");                                            // Get text length, checks for '\0' ending
@@ -1869,7 +1869,7 @@ fn void gl_update_texture(uint id, int offset_x, int offset_y, int width, int he
 fn void gl_get_gl_texture_formats(int format, uint* gl_internal_format, uint* gl_format, uint* gl_type) @cname("rlGetGlTextureFormats"); // Get OpenGL internal formats
 fn char* gl_get_pixel_format_name(uint format) @cname("rlGetPixelFormatName");              // Get name string for pixel format
 fn void gl_unload_texture(uint id) @cname("rlUnloadTexture");                              // Unload texture from GPU memory
-fn void gl_gen_texture_mipmaps(uint id, int width, int height, int format, int *mipmaps) @cname("rlGenTextureMipmaps"); // Generate mipmap data for selected texture
+fn void gl_gen_texture_mipmaps(uint id, int width, int height, int format, int* mipmaps) @cname("rlGenTextureMipmaps"); // Generate mipmap data for selected texture
 fn void* gl_read_texture_pixels(uint id, int width, int height, int format) @cname("rlReadTexturePixels"); // Read texture pixel data
 fn char* gl_read_screen_pixels(int width, int height) @cname("rlReadScreenPixels");           // Read screen pixel data (color buffer)
 
@@ -1879,11 +1879,19 @@ fn void gl_framebuffer_attach(uint fbo_id, uint tex_id, int attach_type, int tex
 fn bool gl_framebuffer_complete(uint id) @cname("rlFramebufferComplete");                        // Verify framebuffer is complete
 fn void gl_unload_framebuffer(uint id) @cname("rlUnloadFramebuffer");                          // Delete framebuffer from GPU
 // WARNING: Copy and resize framebuffer functionality only defined for software backend
-fn void gl_copy_framebuffer(int x, int y, int width, int height, int format, void *pixels) @cname("rlCopyFramebuffer"); // Copy framebuffer pixel data to internal buffer
+fn void gl_copy_framebuffer(int x, int y, int width, int height, int format, void* pixels) @cname("rlCopyFramebuffer"); // Copy framebuffer pixel data to internal buffer
 fn void gl_resize_framebuffer(int width, int height) @cname("rlResizeFramebuffer");                    // Resize internal framebuffer
 
+// Shader compilation type
+constdef RLShaderType : int
+{
+	FRAGMENT = 0x8B30, // GL_FRAGMENT_SHADER
+	VERTEX   = 0x8B31, // GL_VERTEX_SHADER
+	COMPUTE  = 0x91B9  // GL_COMPUTE_SHADER
+}
+
 // Shaders management
-fn uint gl_load_shader(char* code, int type) @cname("rlLoadShader");                    // Load (compile) shader and return shader id (type: RL_VERTEX_SHADER, RL_FRAGMENT_SHADER, RL_COMPUTE_SHADER)
+fn uint gl_load_shader(char* code, RLShaderType type) @cname("rlLoadShader"); // Load (compile) shader and return shader id (type: RL_VERTEX_SHADER, RL_FRAGMENT_SHADER, RL_COMPUTE_SHADER)
 fn uint gl_load_shader_program(char* vs_code, char* fs_code) @cname("rlLoadShaderProgram"); // Load shader from code strings
 fn uint gl_load_shader_program_ex(uint vs_id, uint fs_id) @cname("rlLoadShaderProgramEx"); // Load shader program, using already loaded shader ids
 fn uint gl_load_shader_program_compute(uint cs_id) @cname("rlLoadShaderProgramCompute");               // Load compute shader program
@@ -1905,7 +1913,7 @@ fn uint gl_load_shader_buffer(uint size, void* data, int usage_hint) @cname("rlL
 fn void gl_unload_shader_buffer(uint ssbo_id) @cname("rlUnloadShaderBuffer");                           // Unload shader storage buffer object (SSBO)
 fn void gl_update_shader_buffer(uint id, void* data, uint data_size, uint offset) @cname("rlUpdateShaderBuffer"); // Update SSBO buffer data
 fn void gl_bind_shader_buffer(uint id, uint index) @cname("rlBindShaderBuffer");             // Bind SSBO buffer
-fn void gl_read_shader_buffer(uint id, void *dest, uint count, uint offset) @cname("rlReadShaderBuffer"); // Read SSBO buffer data (GPU->CPU)
+fn void gl_read_shader_buffer(uint id, void* dest, uint count, uint offset) @cname("rlReadShaderBuffer"); // Read SSBO buffer data (GPU->CPU)
 fn void gl_copy_shader_buffer(uint dest_id, uint src_id, uint dest_offset, uint src_offset, uint count) @cname("rlCopyShaderBuffer"); // Copy SSBO data between buffers
 fn uint gl_get_shader_buffer_size(uint id) @cname("rlGetShaderBufferSize");                      // Get SSBO buffer size
 


### PR DESCRIPTION
Fix and add missing `rlgl` bindings for raylib6.

Added the following missing functions:
- `rlSetPointSize()`
- `rlGetPointSize()`
- `rlGetProcAddress()`
- `rlDrawRenderBatchActive()`
- `rlCheckRenderBatchLimit()`

Also updated the shader/program loading bindings that were still targeting the old raylib 5.5 API, and added the new raylib6 variants. And `gl_load_extensions()` has been fixed to point to the correct function.

For render batch bindings, I only added the flush and limit check functions. These are useful when mixing custom rendering with raylib, but I did not add the APIs for creating or setting custom render batches since they would require exposing `rlRenderBatch` and several dependent structures, which are currently not bound, and surely for a good reason.